### PR TITLE
Fix 3 broken citations: KFF, Care.com, Child Care Aware

### DIFF
--- a/audit/links/reviewed.tsv
+++ b/audit/links/reviewed.tsv
@@ -25,3 +25,6 @@
 #
 # url	reviewed_at	reviewed_by	notes
 https://www.hud.gov/hudclips/handbooks/housing-4350-3	2026-05-02	briancorbin	HUD Handbook 4350.3 REV-1, Change 4 (Nov 2013). Confirmed the landing page lists the handbook + chapters; Ch. 3 covers occupancy. Replaces the 404'd /sites/dfiles/OCHCO/documents/4350.3.pdf citation.
+https://www.kff.org/series/employer-health-benefits-survey/	2026-05-03	briancorbin	KFF moved the annual survey to a year-stable series archive. Confirmed the page links to the latest (2025) report with the figures we anchor employer health-insurance employee-share to. Replaces the 404'd /health-costs/report/employer-health-benefits-annual-survey/.
+https://www.care.com/c/cost-of-care-report/	2026-05-03	briancorbin	Care.com renamed the cost-of-care landing page. Confirmed the new URL hosts the current Cost of Care Report with per-metro childcare cost figures. Replaces the 404'd /c/cost-of-childcare/.
+https://www.childcareaware.org/price-landscape24/	2026-05-03	briancorbin	Child Care Aware retired the /state-fact-sheets/ page. The 2024 Price & Supply report at /price-landscape24/ has an interactive state selector with per-state child-care price breakdowns — same content territory we cited the fact sheets for. Year-stamped slug; staleness audit will surface it on the next cycle.

--- a/src/data/sources.ts
+++ b/src/data/sources.ts
@@ -88,7 +88,7 @@ export const SOURCES = {
   },
   'care-com-childcare': {
     label: 'Care.com Cost of Care Report',
-    url: 'https://www.care.com/c/cost-of-childcare/',
+    url: 'https://www.care.com/c/cost-of-care-report/',
     date: '2025',
     tier: 'reference',
     addedBy: 'briancorbin',
@@ -96,7 +96,7 @@ export const SOURCES = {
   },
   'kff-employer-health-benefits': {
     label: 'KFF Employer Health Benefits Survey',
-    url: 'https://www.kff.org/health-costs/report/employer-health-benefits-annual-survey/',
+    url: 'https://www.kff.org/series/employer-health-benefits-survey/',
     date: '2025',
     tier: 'reference',
     addedBy: 'briancorbin',
@@ -159,7 +159,7 @@ export const SOURCES = {
   },
   'child-care-aware': {
     label: 'Child Care Aware — Price of Care',
-    url: 'https://www.childcareaware.org/state-fact-sheets/',
+    url: 'https://www.childcareaware.org/price-landscape24/',
     date: '2025',
     tier: 'reference',
     addedBy: 'briancorbin',


### PR DESCRIPTION
## Summary

Three broken-citation entries from #116 resolved.

| Source | Fix |
|---|---|
| **KFF Employer Health Benefits Survey** | Moved from per-report URL to year-stable `/series/employer-health-benefits-survey/` archive |
| **Care.com Cost of Care Report** | Slug renamed: `/c/cost-of-childcare/` → `/c/cost-of-care-report/` |
| **Child Care Aware — Price of Care** | `/state-fact-sheets/` retired; `/price-landscape24/` carries the per-state price breakdown we cited the fact sheets for |

Each replacement was opened and verified by hand — content matches what the model anchors to (employer health insurance employee-share, per-metro childcare costs, per-state fallback childcare costs respectively).

Per the unified-log convention, each fix has a paired row in `audit/links/reviewed.tsv` describing what was verified and why.

Drains 3 from the broken-citation queue (#116). Once merged, the nightly link audit will refresh the rolling issue.

## Test plan

- [ ] Audit workflow runs cleanly on next nightly cron (or manually via `Run workflow`)
- [ ] Issue #116 body updates to reflect 3 fewer broken
- [ ] /sources page shows green Verified status dots for these three rows after next deploy