### PR TITLE
Citation popover: status indicator + quick report-flag

### DIFF
--- a/src/components/Sources.tsx
+++ b/src/components/Sources.tsx
@@ -14,7 +14,6 @@
  * `audit/links/status.md` on GitHub.
  */
 
-import { useState } from 'react';
 import { theme as T, fonts, rem } from '@/theme';
 import { SectionTitle } from './ui';
 import {
@@ -25,63 +24,18 @@ import {
   STATE_CHIP_AGENCY,
 } from '@/data/sources';
 import type { Source } from '@/types';
-// Vite inlines these files' contents as strings at build time.
-import reviewedTsv from '../../audit/links/reviewed.tsv?raw';
-// `latest.tsv` is overwritten by audit/links/check.sh (run nightly in CI,
-// committed back to main alongside status.md). Importing only this stable
-// filename — instead of glob-importing all dated TSVs — keeps the bundle
-// small as the per-day history accumulates in results/.
-import latestResultsTsv from '../../audit/links/results/latest.tsv?raw';
+import {
+  REVIEWS,
+  STATUS_BY_URL,
+  STALENESS_THRESHOLDS_DAYS,
+  STALENESS_DEFAULT_DAYS,
+  isBrokenStatus,
+  isOverdue,
+  StatusDot,
+  type Review,
+} from '@/lib/sourceStatus';
 
 const GITHUB_REPO = 'https://github.com/TheBudgetAtlas/thebudgetatlas';
-
-interface Review {
-  date: string;
-  reviewer: string;
-  notes: string;
-}
-
-const REVIEWS = parseReviews(reviewedTsv);
-
-/** Status codes we consider "broken" for the rolling audit:link issue + UI display. */
-const BROKEN_STATUS_CODES = new Set(['404', '000', '000ERR', 'ERR', '999']);
-
-function isBrokenStatus(status: string | undefined): boolean {
-  if (!status) return false;
-  return BROKEN_STATUS_CODES.has(status);
-}
-
-const STATUS_BY_URL = (() => {
-  const map = new Map<string, string>();
-  for (const line of latestResultsTsv.split('\n').slice(1)) {
-    if (!line) continue;
-    const [status, url] = line.split('\t');
-    if (url) map.set(url, status);
-  }
-  return map;
-})();
-
-/**
- * Parse `audit/links/reviewed.tsv` into a Map keyed by source id. Reviews
- * are keyed by id (a stable slug), not URL — so when an agency reorganizes
- * a citation's URL, the source's review history follows it. The audit
- * results (latest.tsv) stay URL-keyed, since curl is the thing that's
- * checking URLs.
- */
-function parseReviews(tsv: string): Map<string, Review[]> {
-  const map = new Map<string, Review[]>();
-  for (const line of tsv.split('\n')) {
-    if (!line || line.startsWith('#') || line.startsWith('id\t')) continue;
-    const [id, date, reviewer, notes] = line.split('\t');
-    if (!id) continue;
-    if (!map.has(id)) map.set(id, []);
-    map.get(id)!.push({ date, reviewer, notes: notes ?? '' });
-  }
-  for (const list of map.values()) {
-    list.sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
-  }
-  return map;
-}
 
 interface Group {
   readonly kicker: string;
@@ -182,18 +136,6 @@ const GROUPS: readonly Group[] = [
 
 const ALL_SOURCES = GROUPS.flatMap((g) => g.sources);
 
-/**
- * Tier review thresholds in days — must stay in sync with
- * `audit/staleness/seed-issue.mjs`. The Node script writes the issue;
- * this UI displays the at-a-glance count.
- */
-const STALENESS_THRESHOLDS_DAYS: Record<string, number> = {
-  original: 90,
-  reference: 180,
-  estimate: 365,
-};
-const STALENESS_DEFAULT_DAYS = 180;
-
 const SUMMARY = (() => {
   const total = ALL_SOURCES.length;
   let original = 0;
@@ -243,18 +185,6 @@ const SUMMARY = (() => {
   return { total, original, reference, estimate, reviewed, overdue, broken, verified };
 })();
 
-/** Per-source overdue check — same logic as SUMMARY's loop, used by row rendering. */
-function isOverdue(source: Source): boolean {
-  const tier = source.tier ?? 'reference';
-  const thresholdDays = STALENESS_THRESHOLDS_DAYS[tier] ?? STALENESS_DEFAULT_DAYS;
-  const latest = REVIEWS.get(source.id)?.[0];
-  if (!latest) return true;
-  const reviewDate = new Date(latest.date + 'T00:00:00Z');
-  if (Number.isNaN(reviewDate.valueOf())) return false;
-  const dueDate = new Date(reviewDate);
-  dueDate.setUTCDate(dueDate.getUTCDate() + thresholdDays);
-  return new Date() > dueDate;
-}
 
 export function Sources({ onBack }: { onBack: () => void }) {
   return (
@@ -747,95 +677,6 @@ function MetaStrip({
         />
       )}
     </div>
-  );
-}
-
-/**
- * Compact colored circle to the left of the source title indicating its
- * current state — Broken (red), Overdue (orange), or Verified (green).
- * Hovering reveals an editorial tooltip explaining the state in plain
- * language; aria-label exposes the same to assistive tech.
- */
-function StatusDot({ kind }: { kind: 'broken' | 'overdue' | 'verified' }) {
-  const [hover, setHover] = useState(false);
-  const palette =
-    kind === 'broken'
-      ? {
-          color: T.accent,
-          short: 'Broken',
-          long: 'URL is currently unreachable (404 / error). Needs a fix in sources.ts paired with a row in reviewed.tsv.',
-        }
-      : kind === 'overdue'
-        ? {
-            color: T.warning,
-            short: 'Overdue',
-            long: 'No human review within the tier-specific window. Pick this up during a periodic sweep.',
-          }
-        : {
-            color: T.positive,
-            short: 'Verified',
-            long: 'Loads correctly and has been reviewed by a human within its window.',
-          };
-  return (
-    <span
-      style={{
-        position: 'relative',
-        display: 'inline-flex',
-        alignItems: 'center',
-        flexShrink: 0,
-        alignSelf: 'center',
-        transform: 'translateY(1px)',
-      }}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onFocus={() => setHover(true)}
-      onBlur={() => setHover(false)}
-      tabIndex={0}
-      role="img"
-      aria-label={`${palette.short}: ${palette.long}`}
-    >
-      <span
-        style={{
-          display: 'inline-block',
-          width: 10,
-          height: 10,
-          borderRadius: '50%',
-          background: palette.color,
-        }}
-      />
-      {hover && (
-        <span
-          role="tooltip"
-          style={{
-            position: 'absolute',
-            bottom: 'calc(100% + 8px)',
-            // Anchor to the dot's left edge rather than centering on it. The
-            // dot lives at the far left of each row, so a centered tooltip
-            // overflows the viewport on mobile. Growing rightward keeps it on
-            // screen at any width.
-            left: 0,
-            padding: '8px 12px',
-            background: T.ink,
-            color: T.bg,
-            fontSize: rem(12),
-            lineHeight: 1.4,
-            fontWeight: 400,
-            textTransform: 'none',
-            letterSpacing: '0.01em',
-            borderRadius: 3,
-            whiteSpace: 'normal',
-            width: 'max-content',
-            maxWidth: 'min(260px, calc(100vw - 32px))',
-            boxShadow: '0 4px 16px rgba(0,0,0,0.15)',
-            zIndex: 10,
-            pointerEvents: 'none',
-          }}
-        >
-          <span style={{ fontWeight: 600, color: palette.color }}>{palette.short}</span>
-          <span style={{ color: T.bg }}> — {palette.long}</span>
-        </span>
-      )}
-    </span>
   );
 }
 

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -11,6 +11,7 @@ import { theme as T, fonts, rem } from '@/theme';
 import { fmt } from '@/lib/format';
 import { navigate } from '@/lib/nav';
 import { ALL_SOURCES } from '@/data/sources';
+import { StatusDot, ReportFlag, getStatusKind } from '@/lib/sourceStatus';
 
 /**
  * Editorial citation pill. Renders a small uppercase "SRC" badge in the
@@ -110,35 +111,50 @@ export function CiteGroup({ sources }: { sources: readonly Source[] }) {
           }}
         >
           {sources.map((s, i) => (
-            <a
+            <div
               key={i}
-              href={s.url}
-              target="_blank"
-              rel="noreferrer"
               style={{
-                display: 'block',
-                padding: '6px 14px',
-                color: T.ink,
-                textDecoration: 'none',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 8,
+                padding: '6px 10px 6px 14px',
                 lineHeight: 1.4,
               }}
-              onMouseDown={(e) => e.stopPropagation()}
             >
-              <span>{s.label}</span> <span style={{ color: T.accent, fontWeight: 600 }}>↗</span>
-              <div
+              <span style={{ paddingTop: 4 }}>
+                <StatusDot kind={getStatusKind(s)} size={8} />
+              </span>
+              <a
+                href={s.url}
+                target="_blank"
+                rel="noreferrer"
+                onMouseDown={(e) => e.stopPropagation()}
                 style={{
-                  fontSize: rem(11),
-                  color: T.inkMuted,
-                  marginTop: 2,
-                  display: 'flex',
-                  gap: 8,
-                  alignItems: 'center',
+                  flex: 1,
+                  minWidth: 0,
+                  color: T.ink,
+                  textDecoration: 'none',
                 }}
               >
-                {s.tier && <TierPill tier={s.tier} />}
-                {s.date && <span>{s.date}</span>}
-              </div>
-            </a>
+                <span>{s.label}</span>{' '}
+                <span style={{ color: T.accent, fontWeight: 600 }}>↗</span>
+                <div
+                  style={{
+                    fontSize: rem(11),
+                    color: T.inkMuted,
+                    marginTop: 2,
+                    display: 'flex',
+                    gap: 8,
+                    alignItems: 'center',
+                    flexWrap: 'wrap',
+                  }}
+                >
+                  {s.tier && <TierPill tier={s.tier} />}
+                  {s.date && <span>{s.date}</span>}
+                </div>
+              </a>
+              <ReportFlag source={s} />
+            </div>
           ))}
           <a
             href="/sources"

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -11,7 +11,28 @@ import { theme as T, fonts, rem } from '@/theme';
 import { fmt } from '@/lib/format';
 import { navigate } from '@/lib/nav';
 import { ALL_SOURCES } from '@/data/sources';
-import { StatusDot, ReportFlag, getStatusKind } from '@/lib/sourceStatus';
+import { StatusDot, ReportFlag, getStatusKind, type StatusKind } from '@/lib/sourceStatus';
+
+/**
+ * Roll a list of source statuses up to a single "worst" one. Broken
+ * dominates overdue dominates verified — the goal is honest signal
+ * (one bad apple drives the rollup), not optimism.
+ */
+function worstStatusOf(sources: readonly Source[]): StatusKind {
+  let worst: StatusKind = 'verified';
+  for (const s of sources) {
+    const k = getStatusKind(s);
+    if (k === 'broken') return 'broken';
+    if (k === 'overdue') worst = 'overdue';
+  }
+  return worst;
+}
+
+const STATUS_COLOR: Record<StatusKind, string> = {
+  broken: T.accent,
+  overdue: T.warning,
+  verified: T.positive,
+};
 
 /**
  * Editorial citation pill. Renders a small uppercase "SRC" badge in the
@@ -48,6 +69,7 @@ export function CiteGroup({ sources }: { sources: readonly Source[] }) {
   }, [open]);
 
   if (sources.length === 0) return null;
+  const worstStatus = worstStatusOf(sources);
 
   return (
     <span
@@ -61,11 +83,12 @@ export function CiteGroup({ sources }: { sources: readonly Source[] }) {
           setOpen((o) => !o);
         }}
         aria-expanded={open}
-        aria-label={`${sources.length} sources`}
+        aria-label={`${sources.length} sources, worst status: ${worstStatus}`}
         style={{
           display: 'inline-flex',
           alignItems: 'center',
           justifyContent: 'center',
+          gap: 5,
           fontSize: '0.62em',
           fontFamily: fonts.body,
           fontWeight: 700,
@@ -86,6 +109,19 @@ export function CiteGroup({ sources }: { sources: readonly Source[] }) {
           top: '-0.1em',
         }}
       >
+        {/* Group-status dot mirrors the worst per-row status — broken if any
+            source is unreachable, else overdue if any is stale, else verified.
+            Reader sees an honest health signal without opening the popover. */}
+        <span
+          style={{
+            display: 'inline-block',
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            background: STATUS_COLOR[worstStatus],
+            flexShrink: 0,
+          }}
+        />
         {sources.length === 1 ? 'source · 1 ↗' : `sources · ${sources.length} ↗`}
       </button>
       {open && (

--- a/src/lib/sourceStatus.tsx
+++ b/src/lib/sourceStatus.tsx
@@ -218,6 +218,7 @@ export function StatusDot({
  * into a "give us feedback" call to action.
  */
 export function ReportFlag({ source }: { source: Source }) {
+  const [hover, setHover] = useState(false);
   const params = new URLSearchParams({
     template: 'source-report.yml',
     title: `Report: ${source.label}`,
@@ -225,28 +226,64 @@ export function ReportFlag({ source }: { source: Source }) {
   });
   const href = `${REPO}/issues/new?${params.toString()}`;
   return (
-    <a
-      href={href}
-      target="_blank"
-      rel="noreferrer"
-      title="Report a problem with this citation"
-      aria-label={`Report a problem with ${source.label}`}
-      onMouseDown={(e) => e.stopPropagation()}
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: 22,
-        height: 22,
-        borderRadius: 2,
-        color: T.accent,
-        textDecoration: 'none',
-        flexShrink: 0,
-        fontSize: rem(13),
+    <span
+      style={{ position: 'relative', display: 'inline-flex', flexShrink: 0 }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`Report a problem with ${source.label}`}
+        onMouseDown={(e) => e.stopPropagation()}
+        onFocus={() => setHover(true)}
+        onBlur={() => setHover(false)}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 22,
+          height: 22,
+          borderRadius: 2,
+          color: T.accent,
+          textDecoration: 'none',
+          flexShrink: 0,
+          fontSize: rem(13),
         lineHeight: 1,
       }}
     >
-      ⚑
-    </a>
+        ⚑
+      </a>
+      {hover && (
+        <span
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 6px)',
+            // Anchor to the flag's right edge so the tooltip grows leftward —
+            // the flag sits at the right side of the popover row, so a
+            // left-anchored tooltip would clip on narrow viewports.
+            right: 0,
+            padding: '6px 10px',
+            background: T.ink,
+            color: T.bg,
+            fontSize: rem(11),
+            fontFamily: fonts.body,
+            lineHeight: 1.3,
+            fontWeight: 500,
+            textTransform: 'none',
+            letterSpacing: '0.01em',
+            borderRadius: 3,
+            whiteSpace: 'nowrap',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.15)',
+            zIndex: 10,
+            pointerEvents: 'none',
+          }}
+        >
+          Report a problem
+        </span>
+      )}
+    </span>
   );
 }

--- a/src/lib/sourceStatus.tsx
+++ b/src/lib/sourceStatus.tsx
@@ -239,7 +239,7 @@ export function ReportFlag({ source }: { source: Source }) {
         width: 22,
         height: 22,
         borderRadius: 2,
-        color: T.inkMuted,
+        color: T.accent,
         textDecoration: 'none',
         flexShrink: 0,
         fontSize: rem(13),

--- a/src/lib/sourceStatus.tsx
+++ b/src/lib/sourceStatus.tsx
@@ -111,7 +111,7 @@ const STATUS_PALETTE: Record<
   broken: {
     color: T.accent,
     short: 'Broken',
-    long: 'URL is currently unreachable (404 / error). Needs a fix in sources.ts paired with a row in reviewed.tsv.',
+    long: 'URL is currently unreachable (404 / error). Needs a fix in src/data/sources.ts paired with a row in reviewed.tsv.',
   },
   overdue: {
     color: T.warning,
@@ -219,10 +219,16 @@ export function StatusDot({
  */
 export function ReportFlag({ source }: { source: Source }) {
   const [hover, setHover] = useState(false);
+  // Pre-fill the form's required fields so the reporter lands one step
+  // closer to "submit." `report-date` defaults to today (UTC); the form
+  // copy asks for the day they actually saw the problem, which is
+  // overwhelmingly today — they can edit if it was earlier.
+  const today = new Date().toISOString().slice(0, 10);
   const params = new URLSearchParams({
     template: 'source-report.yml',
     title: `Report: ${source.label}`,
     'source-url': source.url,
+    'report-date': today,
   });
   const href = `${REPO}/issues/new?${params.toString()}`;
   return (

--- a/src/lib/sourceStatus.tsx
+++ b/src/lib/sourceStatus.tsx
@@ -1,0 +1,252 @@
+/**
+ * Shared source-status logic + components.
+ *
+ * Extracted from `components/Sources.tsx` so both the /sources page and the
+ * inline citation popover (`CiteGroup` in `components/ui.tsx`) classify and
+ * render status the same way. One source of truth for:
+ *
+ *   - BROKEN_STATUS_CODES — what counts as broken from curl results.
+ *   - STATUS_BY_URL — latest curl status per URL (built from latest.tsv).
+ *   - REVIEWS — review history per source id (built from reviewed.tsv).
+ *   - isOverdue / getStatusKind — tier-aware staleness check.
+ *   - StatusDot — the green/yellow/red indicator.
+ *   - ReportFlag — quick link to file an audit:report issue.
+ *
+ * Reviews are keyed by stable source id (slug); audit results stay
+ * URL-keyed since curl checks URLs. See audit/links/README.md.
+ */
+
+import { useState } from 'react';
+import { theme as T, fonts, rem } from '@/theme';
+import type { Source } from '@/types';
+// Vite inlines these at build time. Same files the audit pipeline writes.
+import reviewedTsv from '../../audit/links/reviewed.tsv?raw';
+import latestResultsTsv from '../../audit/links/results/latest.tsv?raw';
+
+const REPO = 'https://github.com/TheBudgetAtlas/thebudgetatlas';
+
+export interface Review {
+  date: string;
+  reviewer: string;
+  notes: string;
+}
+
+/** Status codes that classify a citation as broken in the UI + audit issue. */
+export const BROKEN_STATUS_CODES = new Set(['404', '000', '000ERR', 'ERR', '999']);
+
+export function isBrokenStatus(status: string | undefined): boolean {
+  if (!status) return false;
+  return BROKEN_STATUS_CODES.has(status);
+}
+
+/**
+ * Tier review thresholds in days — must stay in sync with
+ * `audit/staleness/seed-issue.mjs`. The Node script writes the issue;
+ * this module drives the UI.
+ */
+export const STALENESS_THRESHOLDS_DAYS: Record<string, number> = {
+  original: 90,
+  reference: 180,
+  estimate: 365,
+};
+export const STALENESS_DEFAULT_DAYS = 180;
+
+/** URL → most recent curl status code, parsed once at module load. */
+export const STATUS_BY_URL = (() => {
+  const map = new Map<string, string>();
+  for (const line of latestResultsTsv.split('\n').slice(1)) {
+    if (!line) continue;
+    const [status, url] = line.split('\t');
+    if (url) map.set(url, status);
+  }
+  return map;
+})();
+
+/**
+ * Parse `audit/links/reviewed.tsv` into a Map keyed by source id (newest
+ * review first within each list). Reviews follow source identity (slug),
+ * not URL — so URL changes don't orphan history.
+ */
+export const REVIEWS = (() => {
+  const map = new Map<string, Review[]>();
+  for (const line of reviewedTsv.split('\n')) {
+    if (!line || line.startsWith('#') || line.startsWith('id\t')) continue;
+    const [id, date, reviewer, notes] = line.split('\t');
+    if (!id) continue;
+    if (!map.has(id)) map.set(id, []);
+    map.get(id)!.push({ date, reviewer, notes: notes ?? '' });
+  }
+  for (const list of map.values()) {
+    list.sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
+  }
+  return map;
+})();
+
+/** Tier-aware overdue check. Never-reviewed sources are overdue from day one. */
+export function isOverdue(source: Source): boolean {
+  const tier = source.tier ?? 'reference';
+  const thresholdDays = STALENESS_THRESHOLDS_DAYS[tier] ?? STALENESS_DEFAULT_DAYS;
+  const latest = REVIEWS.get(source.id)?.[0];
+  if (!latest) return true;
+  const reviewDate = new Date(latest.date + 'T00:00:00Z');
+  if (Number.isNaN(reviewDate.valueOf())) return false;
+  const dueDate = new Date(reviewDate);
+  dueDate.setUTCDate(dueDate.getUTCDate() + thresholdDays);
+  return new Date() > dueDate;
+}
+
+export type StatusKind = 'broken' | 'overdue' | 'verified';
+
+/** Combined status classifier — broken takes precedence, then overdue, then verified. */
+export function getStatusKind(source: Source): StatusKind {
+  if (isBrokenStatus(STATUS_BY_URL.get(source.url))) return 'broken';
+  if (isOverdue(source)) return 'overdue';
+  return 'verified';
+}
+
+const STATUS_PALETTE: Record<
+  StatusKind,
+  { color: string; short: string; long: string }
+> = {
+  broken: {
+    color: T.accent,
+    short: 'Broken',
+    long: 'URL is currently unreachable (404 / error). Needs a fix in sources.ts paired with a row in reviewed.tsv.',
+  },
+  overdue: {
+    color: T.warning,
+    short: 'Overdue',
+    long: 'No human review within the tier-specific window. Pick this up during a periodic sweep.',
+  },
+  verified: {
+    color: T.positive,
+    short: 'Verified',
+    long: 'Loads correctly and has been reviewed by a human within its window.',
+  },
+};
+
+/**
+ * Compact green/yellow/red dot indicating a source's current state.
+ * Hover reveals an editorial tooltip; aria-label exposes the same to ATs.
+ *
+ * `size` defaults to 10px (matching the /sources row); pass a smaller
+ * value for inline-popover use where row density is tighter. `showTooltip`
+ * can be turned off if the dot lives somewhere a hovering tooltip would
+ * overflow or duplicate context already on screen.
+ */
+export function StatusDot({
+  kind,
+  size = 10,
+  showTooltip = true,
+}: {
+  kind: StatusKind;
+  size?: number;
+  showTooltip?: boolean;
+}) {
+  const [hover, setHover] = useState(false);
+  const palette = STATUS_PALETTE[kind];
+  return (
+    <span
+      style={{
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        flexShrink: 0,
+        alignSelf: 'center',
+      }}
+      onMouseEnter={() => showTooltip && setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onFocus={() => showTooltip && setHover(true)}
+      onBlur={() => setHover(false)}
+      tabIndex={showTooltip ? 0 : -1}
+      role="img"
+      aria-label={`${palette.short}: ${palette.long}`}
+    >
+      <span
+        style={{
+          display: 'inline-block',
+          width: size,
+          height: size,
+          borderRadius: '50%',
+          background: palette.color,
+        }}
+      />
+      {hover && showTooltip && (
+        <span
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            bottom: 'calc(100% + 8px)',
+            // Anchor to the dot's left edge rather than centering on it.
+            // Centered tooltips clip on mobile when the dot lives at the
+            // far left of a row.
+            left: 0,
+            padding: '8px 12px',
+            background: T.ink,
+            color: T.bg,
+            fontSize: rem(12),
+            fontFamily: fonts.body,
+            lineHeight: 1.4,
+            fontWeight: 400,
+            textTransform: 'none',
+            letterSpacing: '0.01em',
+            borderRadius: 3,
+            whiteSpace: 'normal',
+            width: 'max-content',
+            maxWidth: 'min(260px, calc(100vw - 32px))',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.15)',
+            zIndex: 10,
+            pointerEvents: 'none',
+          }}
+        >
+          <span style={{ fontWeight: 600, color: palette.color }}>{palette.short}</span>
+          <span style={{ color: T.bg }}> — {palette.long}</span>
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Quick "report a problem" affordance for a citation. Renders a small
+ * flag icon that opens the source-report issue template in a new tab,
+ * pre-filling the source URL field. Title gets a placeholder pulled
+ * from the source label so triagers know which citation it concerns.
+ *
+ * Intentionally subtle — the goal is to make reporting frictionless for
+ * a reader who notices something off, without turning every citation
+ * into a "give us feedback" call to action.
+ */
+export function ReportFlag({ source }: { source: Source }) {
+  const params = new URLSearchParams({
+    template: 'source-report.yml',
+    title: `Report: ${source.label}`,
+    'source-url': source.url,
+  });
+  const href = `${REPO}/issues/new?${params.toString()}`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      title="Report a problem with this citation"
+      aria-label={`Report a problem with ${source.label}`}
+      onMouseDown={(e) => e.stopPropagation()}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 22,
+        height: 22,
+        borderRadius: 2,
+        color: T.inkMuted,
+        textDecoration: 'none',
+        flexShrink: 0,
+        fontSize: rem(13),
+        lineHeight: 1,
+      }}
+    >
+      ⚑
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

The citation pill and its popover now surface verification health at a glance, and let readers escalate problems without leaving the page. Three changes:

1. **Roll-up status dot on the citation pill itself** — small colored dot inside `source · N ↗` reflects the worst per-source state across the group: broken (red) > overdue (yellow) > verified (green). Honest signal: one bad apple drives the rollup.
2. **Per-row status dot in the popover** — same green/yellow/red as /sources, classified by the same logic.
3. **Quick report-flag (⚑) per row** — opens the [source-report issue template](https://github.com/TheBudgetAtlas/thebudgetatlas/issues/new?template=source-report.yml) in a new tab with `source-url` and `title` pre-filled. Hover/focus → tooltip "Report a problem". Tinted red so it reads as escalation.

## Layout

Pill (single citation):

```
[ ● ] source · 1 ↗
```

Popover row:

```
[ ● ]  [ Source label ↗ + tier pill + date ]  [ ⚑ ]
```

Status dot and flag are independent click targets — fixes a previously-nested-anchor invalid-HTML pattern in the process.

## Shared module

Status logic + components lift out of `components/Sources.tsx` into a new `src/lib/sourceStatus.tsx`:

- `STATUS_BY_URL`, `REVIEWS`, `isBrokenStatus`, `isOverdue`
- `getStatusKind(source)` → `'broken' | 'overdue' | 'verified'`
- `StatusDot` (with optional tooltip + size)
- `ReportFlag` (with hover tooltip)

`/sources` page and the inline popover now classify and render the same way — single source of truth.

## Test plan

- [x] Typecheck clean
- [ ] Citation pill shows a colored dot reflecting the worst source status
- [ ] Click pill → popover rows each show a dot matching their state
- [ ] Hover any dot → tooltip explains broken/overdue/verified
- [ ] Click ⚑ → opens issue form in new tab with URL + title pre-filled
- [ ] Hover ⚑ → "Report a problem" tooltip
- [ ] Mobile: tooltips don't clip; flag is tappable