### PR TITLE
Add CI: lint + format + typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+# Lint, format, and typecheck checks for every PR + every push to main.
+# Fast (~30s with cache), runs in parallel, blocks merge if anything fails.
+#
+# Branch protection on main should require this workflow's "checks" job
+# before merging — set in Settings → Branches → Branch protection rules.
+# Requiring the job (rather than each step) lets us add new checks here
+# without re-configuring branch protection.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Newer pushes to the same PR/branch cancel in-flight runs — saves CI
+# minutes when someone pushes a quick fixup.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        # `--immutable` fails the run if yarn.lock would need updates,
+        # which is what we want on CI: locked deps, deterministic checks.
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Format check
+        run: yarn format:check
+
+      - name: Typecheck
+        run: yarn typecheck


### PR DESCRIPTION
## Summary

Single workflow runs three checks on every PR and every push to main:

- `yarn lint` — ESLint, 0 errors required
- `yarn format:check` — Prettier
- `yarn typecheck` — `tsc --noEmit`, 0 errors required

All three currently pass on main as of #120 (which fixed the .mjs Node-globals lint failures).

## Behavior

- **Triggers**: `pull_request` (target = main) + `push` (main).
- **Concurrency**: in-flight runs cancel when a newer commit lands on the same PR/branch — saves minutes on rapid fixup pushes.
- **Permissions**: read-only (no token write needed).
- **Timeout**: 5 minutes (typical run is well under 1).

## Branch protection (manual step after merge)

Once this lands, configure on GitHub:

> **Settings → Branches → Branch protection rules → main → Require status checks to pass before merging**
> Add: `checks`

This makes CI mandatory for merge.

## What it doesn't do (yet)

- No `--max-warnings 0` on lint — there are 7 pre-existing `react-refresh/only-export-components` warnings in `ui.tsx` that we've accepted. Fixable in a follow-up; not blocking CI for now.
- No build smoke test (`yarn build`). Could add later if production-build regressions become a concern.
- No tests (no test suite exists yet).

## Test plan

- [x] `yarn lint`, `yarn format:check`, `yarn typecheck` all pass locally
- [ ] CI run on this PR succeeds
- [ ] After merge, configure branch protection to require `checks`