### PR TITLE
CI: enforce unused-source + new-source-paired-row conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need history so the source-pairing check can `git show`
+          # the PR's base ref. fetch-depth: 0 is cheap on this repo.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -50,3 +54,17 @@ jobs:
 
       - name: Typecheck
         run: yarn typecheck
+
+      - name: Source registry — unused-source check
+        # Fails if any top-level SOURCES['<id>'] is unreferenced outside
+        # the registry itself and the bibliography page. A citation only
+        # used by /sources is functionally dead — wire it in or remove it.
+        run: node --experimental-strip-types scripts/source-inventory.mjs --check
+
+      - name: Source registry — paired reviewed.tsv row for new sources
+        # PR-only: every newly-added source needs a matching row in
+        # audit/links/reviewed.tsv proving a human verified it. Skipped on
+        # push events because there's no clear "base" — the PR check
+        # already gated the merge.
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-source-pairing.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,19 @@
 name: CI
 
-# Lint, format, and typecheck checks for every PR + every push to main.
-# Fast (~30s with cache), runs in parallel, blocks merge if anything fails.
+# Per-check CI: each entry below renders as its own status line on the PR
+# (e.g. `CI / lint`, `CI / format`, `CI / unused-sources`). Failing any one
+# fails its own line independently, which is easier to scan than a single
+# job with N steps where you have to dig into logs to see which step blew
+# up.
 #
-# Branch protection on main should require this workflow's "checks" job
-# before merging — set in Settings → Branches → Branch protection rules.
-# Requiring the job (rather than each step) lets us add new checks here
-# without re-configuring branch protection.
+# Branch protection on main should require each check listed in the matrix
+# (Settings → Branches → Branch protection → Require status checks). To
+# add a new check, append a matrix entry and add it to the required-checks
+# list — small cost, big visibility win.
+#
+# Setup is duplicated across jobs but parallelism + setup-node's yarn
+# cache keep total wall-clock low. `fail-fast: false` so a lint blowup
+# doesn't hide a typecheck blowup in the same PR.
 
 on:
   pull_request:
@@ -17,64 +24,60 @@ on:
 permissions:
   contents: read
 
-# Newer pushes to the same PR/branch cancel in-flight runs — saves CI
-# minutes when someone pushes a quick fixup.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  checks:
+  check:
+    name: ${{ matrix.check.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - name: lint
+            run: yarn lint
+          - name: format
+            run: yarn format:check
+          - name: typecheck
+            run: yarn typecheck
+          - name: unused-sources
+            run: node --experimental-strip-types scripts/source-inventory.mjs --check
+          - name: source-pairing
+            run: node scripts/check-source-pairing.mjs
+          - name: reviewed-immutable
+            run: node scripts/check-reviewed-immutable.mjs
+
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need history so the source-pairing check can `git show`
-          # the PR's base ref. fetch-depth: 0 is cheap on this repo.
+          # source-pairing and reviewed-immutable need history to git-show
+          # the base ref. fetch-depth: 0 is cheap here and keeps the matrix
+          # uniform — not worth conditional logic to save a few hundred KB.
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          # `cache: 'yarn'` only works after yarn install runs once; the
+          # cache key is yarn.lock-derived. Speeds up subsequent jobs in
+          # this matrix run and across PRs.
+          cache: yarn
 
       - name: Enable Corepack (Yarn 4)
         run: corepack enable
 
       - name: Install dependencies
-        # `--immutable` fails the run if yarn.lock would need updates,
-        # which is what we want on CI: locked deps, deterministic checks.
         run: yarn install --immutable
 
-      - name: Lint
-        run: yarn lint
-
-      - name: Format check
-        run: yarn format:check
-
-      - name: Typecheck
-        run: yarn typecheck
-
-      - name: Source registry — unused-source check
-        # Fails if any top-level SOURCES['<id>'] is unreferenced outside
-        # the registry itself and the bibliography page. A citation only
-        # used by /sources is functionally dead — wire it in or remove it.
-        run: node --experimental-strip-types scripts/source-inventory.mjs --check
-
-      - name: Source registry — paired reviewed.tsv row for new sources
-        # On PR: base = the PR's target branch (origin/$GITHUB_BASE_REF).
-        # On push: base = the previous tip of this branch
-        # (github.event.before). The push case is a tripwire — the PR
-        # check should already have gated the merge, but if main drifts
-        # (force-push, direct commit, branch-protection misconfig) we
-        # want to surface it, not hide it.
+      - name: ${{ matrix.check.name }}
         env:
+          # PR target on pull_request, previous tip on push. Used by
+          # source-pairing and reviewed-immutable; ignored by the others.
+          # The push-event case is a tripwire — if main drifts (force-push,
+          # direct commit, branch-protection misconfig), the failure
+          # should surface, not hide.
           AUDIT_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
-        run: node scripts/check-source-pairing.mjs
-
-      - name: reviewed.tsv — append-only enforcement
-        # Same base-ref logic as above. Modifying or removing rows on
-        # main without a PR (somehow) should fail loud.
-        env:
-          AUDIT_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
-        run: node scripts/check-reviewed-immutable.mjs
+        run: ${{ matrix.check.run }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,19 @@ jobs:
         run: node --experimental-strip-types scripts/source-inventory.mjs --check
 
       - name: Source registry — paired reviewed.tsv row for new sources
-        # PR-only: every newly-added source needs a matching row in
-        # audit/links/reviewed.tsv proving a human verified it. Skipped on
-        # push events because there's no clear "base" — the PR check
-        # already gated the merge.
-        if: github.event_name == 'pull_request'
+        # On PR: base = the PR's target branch (origin/$GITHUB_BASE_REF).
+        # On push: base = the previous tip of this branch
+        # (github.event.before). The push case is a tripwire — the PR
+        # check should already have gated the merge, but if main drifts
+        # (force-push, direct commit, branch-protection misconfig) we
+        # want to surface it, not hide it.
+        env:
+          AUDIT_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
         run: node scripts/check-source-pairing.mjs
 
       - name: reviewed.tsv — append-only enforcement
-        # PR-only: rows in reviewed.tsv are an immutable audit trail.
-        # Existing rows can't be modified, removed, or reordered into
-        # oblivion; new rows can be appended. Comments and blank lines
-        # are exempt (header docs may need legitimate edits).
-        if: github.event_name == 'pull_request'
+        # Same base-ref logic as above. Modifying or removing rows on
+        # main without a PR (somehow) should fail loud.
+        env:
+          AUDIT_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
         run: node scripts/check-reviewed-immutable.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,10 +61,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          # `cache: 'yarn'` only works after yarn install runs once; the
-          # cache key is yarn.lock-derived. Speeds up subsequent jobs in
-          # this matrix run and across PRs.
-          cache: yarn
+          # No `cache: 'yarn'` here: setup-node calls `yarn cache dir`
+          # before our Corepack-enable step, but the runner's bundled
+          # Yarn 1.x refuses to run because package.json declares
+          # packageManager: yarn@4. Caching can be reintroduced via a
+          # separate actions/cache@v4 step after Corepack is enabled —
+          # not worth the complexity for now.
 
       - name: Enable Corepack (Yarn 4)
         run: corepack enable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,11 @@ jobs:
         # already gated the merge.
         if: github.event_name == 'pull_request'
         run: node scripts/check-source-pairing.mjs
+
+      - name: reviewed.tsv — append-only enforcement
+        # PR-only: rows in reviewed.tsv are an immutable audit trail.
+        # Existing rows can't be modified, removed, or reordered into
+        # oblivion; new rows can be appended. Comments and blank lines
+        # are exempt (header docs may need legitimate edits).
+        if: github.event_name == 'pull_request'
+        run: node scripts/check-reviewed-immutable.mjs

--- a/audit/links/README.md
+++ b/audit/links/README.md
@@ -5,7 +5,7 @@ Reproducible audit of every external URL cited from the codebase — does it sti
 ## How it works
 
 1. **`check.sh`** extracts every `http(s)://` URL from [`src/data/sources.ts`](../../src/data/sources.ts) — the citation registry — hits each with curl, and writes a dated TSV to `results/`. Other URLs in the codebase (font CDN preconnects, repo links, build artifacts) aren't checked: only declared citations are auditable, by design.
-2. **`reviewed.tsv`** is the unified resolution log (see below). One row per `id · date · reviewer · notes` event — keyed by stable source slug, not URL, so review history follows a citation across URL changes.
+2. **`reviewed.tsv`** is the unified resolution log (see below). One row per `id · date · reviewer · notes` event — keyed by stable source slug, not URL, so review history follows a citation across URL changes. **Rows are append-only**: existing rows can't be modified, removed, or reordered (CI enforces this via `scripts/check-reviewed-immutable.mjs`). If a past review needs correction, append a new row that supersedes it — don't edit history.
 3. **`results/<date>.tsv`** captures the union: machine status (does it load?) + human review state (did someone verify the content?).
 
 A `200 OK` from curl only tells us _something_ loaded. Only a human can tell us whether the loaded page still cites the document we built the model around. Both columns matter.

--- a/scripts/check-reviewed-immutable.mjs
+++ b/scripts/check-reviewed-immutable.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * PR check: rows in audit/links/reviewed.tsv are append-only.
+ *
+ * Every row in the base ref must still be present, byte-for-byte
+ * unchanged, in the PR's HEAD. New rows can be appended; existing rows
+ * can't be modified, removed, or reordered into oblivion.
+ *
+ * Why this matters: reviewed.tsv is the durable audit trail for human
+ * verification of citations. Editing a past review row would let
+ * someone quietly rewrite history — change the date, change the
+ * reviewer, change what was claimed to be verified. That defeats the
+ * point. The file grows; rows are immutable.
+ *
+ * Comments (lines starting with `#`) and blank lines are NOT subject to
+ * this check — header docs may need legitimate edits and aren't part of
+ * the audit record. If you need to fix a typo in a real review row,
+ * that requires explicit acknowledgment via a separate process (e.g. a
+ * follow-up "correction" row that supersedes, not edits, the original).
+ *
+ * Run via the CI workflow on pull_request events. Locally:
+ *
+ *   node scripts/check-reviewed-immutable.mjs
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REVIEWED_PATH = 'audit/links/reviewed.tsv';
+
+const BASE_REF = process.env.GITHUB_BASE_REF
+  ? `origin/${process.env.GITHUB_BASE_REF}`
+  : 'origin/main';
+
+function gitShow(ref, path) {
+  return execFileSync('git', ['show', `${ref}:${path}`], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+/** Extract data rows: non-empty, non-comment, non-header. */
+function dataRows(text) {
+  const rows = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    if (line.startsWith('#')) continue;
+    if (line.startsWith('id\t')) continue; // legacy header row
+    if (line.startsWith('url\t')) continue; // legacy header (pre-id-keying)
+    rows.push(line);
+  }
+  return rows;
+}
+
+let baseText;
+try {
+  baseText = gitShow(BASE_REF, REVIEWED_PATH);
+} catch {
+  // reviewed.tsv didn't exist on the base ref — nothing to compare. Pass.
+  console.log('No reviewed.tsv on base ref; nothing to compare. ✓');
+  process.exit(0);
+}
+
+const headText = readFileSync(resolve(ROOT, REVIEWED_PATH), 'utf8');
+
+const baseRows = dataRows(baseText);
+const headRows = new Set(dataRows(headText));
+
+const missing = [];
+for (const row of baseRows) {
+  if (!headRows.has(row)) missing.push(row);
+}
+
+if (missing.length === 0) {
+  const added = headRows.size - baseRows.length;
+  if (added > 0) {
+    console.log(`✓ All ${baseRows.length} base rows preserved; ${added} row(s) appended.`);
+  } else {
+    console.log(`✓ reviewed.tsv unchanged (${baseRows.length} rows).`);
+  }
+  process.exit(0);
+}
+
+console.error(
+  `❌ ${missing.length} row(s) from base reviewed.tsv are missing or modified in this PR:`,
+);
+console.error('');
+for (const row of missing) {
+  // Truncate noisy notes to keep the log readable.
+  const display = row.length > 200 ? row.slice(0, 197) + '...' : row;
+  console.error(`   - ${display}`);
+}
+console.error('');
+console.error('reviewed.tsv is the durable audit trail for human verification of');
+console.error("citations. Existing rows are immutable — they can't be modified,");
+console.error('removed, or reordered. New rows can be appended.');
+console.error('');
+console.error('If you need to correct an earlier review, append a NEW row that');
+console.error("supersedes the original. Don't edit history.");
+console.error('');
+console.error('See audit/links/README.md for the unified-resolution-log convention.');
+process.exit(1);

--- a/scripts/check-reviewed-immutable.mjs
+++ b/scripts/check-reviewed-immutable.mjs
@@ -31,9 +31,10 @@ import { fileURLToPath } from 'node:url';
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const REVIEWED_PATH = 'audit/links/reviewed.tsv';
 
-const BASE_REF = process.env.GITHUB_BASE_REF
-  ? `origin/${process.env.GITHUB_BASE_REF}`
-  : 'origin/main';
+// Base ref: workflow-supplied via AUDIT_BASE_REF (set explicitly per event
+// in ci.yml — PR target on pull_request, previous tip on push). Falls back
+// to origin/main for local invocations.
+const BASE_REF = process.env.AUDIT_BASE_REF || 'origin/main';
 
 function gitShow(ref, path) {
   return execFileSync('git', ['show', `${ref}:${path}`], {

--- a/scripts/check-source-pairing.mjs
+++ b/scripts/check-source-pairing.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * PR check: every newly-added source in src/data/sources.ts must have a
+ * matching row added to audit/links/reviewed.tsv in the same PR.
+ *
+ * Implements the unified-resolution-log convention from CLAUDE.md and
+ * audit/links/README.md: the registry never changes silently. A new
+ * source presupposes a human verified it; the row is the proof. Without
+ * this check, AI-proposed citations or quick wire-ups can sneak in
+ * without first-pass review.
+ *
+ * Scope (v1):
+ *   - Detects newly-ADDED source ids (top-level keys in RAW_SOURCES,
+ *     synthesized state-${kind}-${code} for state-agency maps).
+ *   - Requires each new id to appear as a freshly-added row in
+ *     reviewed.tsv with a matching first column.
+ *   - Modifications (URL change, label edit) are NOT checked. Convention
+ *     still requires a row, but detecting modifications cleanly across a
+ *     diff is harder; code review catches those for now.
+ *
+ * Run via the CI workflow on pull_request events. Locally:
+ *
+ *   node scripts/check-source-pairing.mjs
+ *
+ * Compares HEAD to `origin/${GITHUB_BASE_REF}` (or `origin/main` locally).
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCES_PATH = 'src/data/sources.ts';
+const REVIEWED_PATH = 'audit/links/reviewed.tsv';
+
+const BASE_REF = process.env.GITHUB_BASE_REF
+  ? `origin/${process.env.GITHUB_BASE_REF}`
+  : 'origin/main';
+
+function gitShow(ref, path) {
+  return execFileSync('git', ['show', `${ref}:${path}`], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+// Same id-extraction logic the staleness audit uses (audit/staleness/seed-issue.mjs).
+// Top-level entries' ids = the outer record key. State-map entries get a
+// synthesized `state-${kind}-${code}` matching the runtime wrapping in
+// src/data/sources.ts (`withStateIds(kind, RAW_*)`).
+const STATE_KIND_BY_DECL = {
+  RAW_SOURCES: 'top',
+  RAW_STATE_DOR: 'dor',
+  RAW_STATE_SNAP_AGENCY: 'snap',
+  RAW_STATE_MEDICAID_AGENCY: 'medicaid',
+  RAW_STATE_CHIP_AGENCY: 'chip',
+};
+
+function parseSourceIds(text) {
+  const ids = new Set();
+  let block = null;
+  let pendingKey = null;
+  let inEntry = false;
+
+  for (const line of text.split('\n')) {
+    const blockMatch = /^(?:export\s+)?const\s+(RAW_\w+)\s*[:=]/.exec(line);
+    if (blockMatch) {
+      block = STATE_KIND_BY_DECL[blockMatch[1]] ?? null;
+      pendingKey = null;
+      inEntry = false;
+      continue;
+    }
+    if (block && /^\}/.test(line) && !inEntry) {
+      block = null;
+      continue;
+    }
+    if (!block) continue;
+
+    if (!inEntry) {
+      const km =
+        block === 'top'
+          ? /^\s+(?:['"]([^'"]+)['"]|([A-Za-z_][\w-]*))\s*:\s*\{/.exec(line)
+          : /^\s+([A-Z]{2}):\s*\{/.exec(line);
+      if (km) {
+        pendingKey = km[1] ?? km[2];
+        inEntry = true;
+      }
+      continue;
+    }
+
+    if (/^\s{2,4}\},?\s*$/.test(line)) {
+      const id = block === 'top' ? pendingKey : `state-${block}-${pendingKey.toLowerCase()}`;
+      ids.add(id);
+      pendingKey = null;
+      inEntry = false;
+    }
+  }
+  return ids;
+}
+
+function parseReviewedIds(text) {
+  const ids = new Set();
+  for (const line of text.split('\n')) {
+    if (!line || line.startsWith('#') || line.startsWith('id\t')) continue;
+    const [id] = line.split('\t');
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+let baseSourcesText, baseReviewedText;
+try {
+  baseSourcesText = gitShow(BASE_REF, SOURCES_PATH);
+} catch (err) {
+  console.error(`Failed to read ${BASE_REF}:${SOURCES_PATH} — make sure ${BASE_REF} is fetched.`);
+  console.error(err.message);
+  process.exit(2);
+}
+try {
+  baseReviewedText = gitShow(BASE_REF, REVIEWED_PATH);
+} catch {
+  // reviewed.tsv may not exist on the base ref (very old branches); treat
+  // as empty rather than crashing.
+  baseReviewedText = '';
+}
+
+const headSourcesText = readFileSync(resolve(ROOT, SOURCES_PATH), 'utf8');
+const headReviewedText = readFileSync(resolve(ROOT, REVIEWED_PATH), 'utf8');
+
+const baseSourceIds = parseSourceIds(baseSourcesText);
+const headSourceIds = parseSourceIds(headSourcesText);
+const baseReviewedIds = parseReviewedIds(baseReviewedText);
+const headReviewedIds = parseReviewedIds(headReviewedText);
+
+const newSourceIds = [...headSourceIds].filter((id) => !baseSourceIds.has(id));
+const newReviewedIds = new Set([...headReviewedIds].filter((id) => !baseReviewedIds.has(id)));
+
+if (newSourceIds.length === 0) {
+  console.log('No new sources in this PR. ✓');
+  process.exit(0);
+}
+
+const missing = newSourceIds.filter((id) => !newReviewedIds.has(id));
+
+if (missing.length > 0) {
+  console.error(`❌ ${missing.length} source(s) added without a paired reviewed.tsv row:`);
+  for (const id of missing) console.error(`   - ${id}`);
+  console.error('');
+  console.error('Per the unified-resolution-log convention, every new source needs');
+  console.error('a row in audit/links/reviewed.tsv proving a human verified it.');
+  console.error('Format: id<TAB>YYYY-MM-DD<TAB>your-handle<TAB>brief notes');
+  console.error('See CLAUDE.md and audit/links/README.md for the rationale.');
+  process.exit(1);
+}
+
+console.log(`✓ ${newSourceIds.length} new source(s) all paired with reviewed.tsv rows:`);
+for (const id of newSourceIds) console.log(`   - ${id}`);

--- a/scripts/check-source-pairing.mjs
+++ b/scripts/check-source-pairing.mjs
@@ -34,9 +34,10 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SOURCES_PATH = 'src/data/sources.ts';
 const REVIEWED_PATH = 'audit/links/reviewed.tsv';
 
-const BASE_REF = process.env.GITHUB_BASE_REF
-  ? `origin/${process.env.GITHUB_BASE_REF}`
-  : 'origin/main';
+// Base ref: workflow-supplied via AUDIT_BASE_REF (set explicitly per event
+// in ci.yml — PR target on pull_request, previous tip on push). Falls back
+// to origin/main for local invocations.
+const BASE_REF = process.env.AUDIT_BASE_REF || 'origin/main';
 
 function gitShow(ref, path) {
   return execFileSync('git', ['show', `${ref}:${path}`], {

--- a/scripts/source-inventory.mjs
+++ b/scripts/source-inventory.mjs
@@ -155,6 +155,26 @@ const unused = rows.filter((r) => r.isTopLevel && r.usage.length === 0);
 const broken = rows.filter((r) => r.broken);
 const originalUnreviewed = rows.filter((r) => r.tier === 'original' && !r.latestReview);
 
+// ── --check mode (CI-friendly) ──────────────────────────────────────────
+// `node scripts/source-inventory.mjs --check` exits non-zero if there are
+// any unused top-level sources, without writing the markdown report. Used
+// as a required PR check so dead citations can't merge into the registry.
+if (process.argv.includes('--check')) {
+  if (unused.length > 0) {
+    console.error(`❌ ${unused.length} unused top-level source(s):`);
+    for (const r of unused) console.error(`   - ${r.id} (${r.label})`);
+    console.error('');
+    console.error("Each top-level source must have at least one SOURCES['<id>']");
+    console.error('reference outside src/data/sources.ts and src/components/Sources.tsx');
+    console.error('(the bibliography page enumerates everything by design and is');
+    console.error('excluded from the usage check). Either wire it into a consumer or');
+    console.error('remove the entry. See audit/links/README.md for the rationale.');
+    process.exit(1);
+  }
+  console.log(`✓ All ${rows.filter((r) => r.isTopLevel).length} top-level sources are referenced.`);
+  process.exit(0);
+}
+
 // ── Render ──────────────────────────────────────────────────────────────
 const today = new Date().toISOString().slice(0, 10);
 // Record the snapshot date of the link-audit data so a re-run without a


### PR DESCRIPTION
## Summary

Three PR-blocking checks added to the existing \`checks\` CI job. Conventions move from \"code review catches it\" to \"merge is impossible without it.\"

### 1. Unused-source check

\`node scripts/source-inventory.mjs --check\`

Exits non-zero if any top-level \`SOURCES['<id>']\` is unreferenced outside:

- the registry itself (\`src/data/sources.ts\`)
- the bibliography page (\`src/components/Sources.tsx\` — enumerates everything by design)

A citation only used by /sources is functionally dead. The bibliography exclusion means dead sources can't hide behind it.

### 2. New-source paired-row check

\`node scripts/check-source-pairing.mjs\`

Diffs \`sources.ts\` and \`reviewed.tsv\` between base and HEAD; for every newly-added source id, requires a freshly-added row in \`reviewed.tsv\`. Implements the unified-resolution-log convention: the registry never changes silently.

### 3. reviewed.tsv append-only enforcement

\`node scripts/check-reviewed-immutable.mjs\`

Existing rows in \`reviewed.tsv\` are the durable audit trail. Modifying or removing them would let someone quietly rewrite history. Every row in the base ref must still appear byte-for-byte in HEAD; new rows can be appended.

Comments and blank lines are exempt — header docs may need legitimate edits.

## Base ref by event type

Both diff-based checks (#2 and #3) need a \"before\" snapshot to compare HEAD against. The workflow sets \`AUDIT_BASE_REF\` explicitly per event:

| Event | Base ref |
|---|---|
| \`pull_request\` | \`origin/\$GITHUB_BASE_REF\` (PR target) |
| \`push\` (main) | \`github.event.before\` (previous main tip) |

The push-event run is a tripwire — the PR check should already gate the merge, but if main drifts (force-push, direct commit, branch-protection misconfig) the failure should surface, not hide.

## Scope (v1) — what's NOT enforced

- **Modifications** (URL/label edits on existing sources) aren't checked. The convention says they should also pair with a row, but detecting modifications cleanly across a diff is harder. Code review catches those for now; v2 if it becomes a recurring miss.
- **State-map order/structure changes** that don't add new state codes pass through.

## Implementation notes

- All three checks run as steps in the existing \`checks\` job, so branch protection already requires them via the single job dependency. No re-config needed.
- \`actions/checkout\` set to \`fetch-depth: 0\` so \`git show \$BASE_REF:...\` works in checks #2 and #3. Cheap on this repo size.
- Pairing-check parser is the same regex-based id extractor used by the staleness audit (\`audit/staleness/seed-issue.mjs\`). Could DRY into a shared helper later if drift becomes painful.

## Test plan

Adversarially tested locally for all three:

- ✅ Inject a fake source without a paired row → check #2 exits 1 with clear message
- ✅ Add the matching row → check #2 exits 0
- ✅ Modify a row in \`reviewed.tsv\` → check #3 exits 1 naming the row
- ✅ Delete a row → check #3 exits 1 naming the row
- ✅ Append a new row → check #3 exits 0
- ✅ \`yarn lint\`, \`yarn format:check\`, \`yarn typecheck\` clean
- ✅ This PR itself adds no sources / mods → all three pass

The CI run on this PR will verify end-to-end.