### PR TITLE
Add Dependabot for npm + github-actions weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update schedule for npm and github-actions
- Groups minor/patch updates so PRs don't proliferate
- Sets `open-pull-requests-limit: 99` on both ecosystems (effectively uncapped)

## Test plan
- [ ] After merge, check Insights → Dependency graph → Dependabot to confirm config parsed
- [ ] First scheduled run should produce PRs within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)