### PR TITLE
Add Vitest + unit tests for src/lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
             run: yarn format:check
           - name: typecheck
             run: yarn typecheck
+          - name: test
+            run: yarn test
           - name: unused-sources
             run: node --experimental-strip-types scripts/source-inventory.mjs --check
           - name: source-pairing

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "tunnel": "./scripts/tunnel.sh",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "verify": "yarn typecheck && yarn lint && yarn format:check",
+    "verify": "yarn typecheck && yarn lint && yarn format:check && yarn test",
     "render-branding": "./scripts/render-branding.sh",
     "check-links": "./audit/links/check.sh",
     "audit:seed-issues": "node audit/links/seed-issues.mjs",
@@ -45,6 +47,7 @@
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/lib/benefits.test.ts
+++ b/src/lib/benefits.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkBenefit,
+  checkChip,
+  checkMedicaid,
+  checkSnap,
+  type BenefitInputs,
+} from '@/lib/benefits';
+
+function inputs(overrides: Partial<BenefitInputs> = {}): BenefitInputs {
+  return {
+    grossIncome: 20_000,
+    householdSize: 3,
+    state: 'OH',
+    adults: 1,
+    kids: 2,
+    monthlyHealthcareCost: 800,
+    monthlyHealthcareSingle: 350,
+    ...overrides,
+  };
+}
+
+describe('checkSnap', () => {
+  it('rejects empty households cleanly', () => {
+    const r = checkSnap(inputs({ householdSize: 0 }));
+    expect(r.eligible).toBe(false);
+    expect(r.monthlyBenefit).toBe(0);
+  });
+
+  it('returns ineligible above the state gross-income limit', () => {
+    // OH uses BBCE at 130% federal floor for SNAP; 3-person 100% FPL = $27,320,
+    // so $200K is unambiguously over.
+    const r = checkSnap(inputs({ grossIncome: 200_000 }));
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/exceeds/i);
+    expect(r.monthlyBenefit).toBe(0);
+  });
+
+  it('returns a non-negative monthly benefit when eligible', () => {
+    const r = checkSnap(inputs({ grossIncome: 18_000, householdSize: 3 }));
+    expect(r.eligible).toBe(true);
+    expect(r.monthlyBenefit).toBeGreaterThan(0);
+    expect(r.monthlyBenefit).toBeLessThanOrEqual(785); // FY2026 max for HH=3
+  });
+
+  it('benefit decreases as income rises (still within eligibility)', () => {
+    const low = checkSnap(inputs({ grossIncome: 12_000, householdSize: 3 }));
+    const high = checkSnap(inputs({ grossIncome: 25_000, householdSize: 3 }));
+    expect(low.eligible && high.eligible).toBe(true);
+    expect(low.monthlyBenefit).toBeGreaterThan(high.monthlyBenefit);
+  });
+
+  it('notes BBCE explicitly when a state has expanded the limit', () => {
+    // CA is on the 200% BBCE list.
+    const r = checkSnap(inputs({ state: 'CA', grossIncome: 20_000 }));
+    expect(r.policyNote).toMatch(/Broad-Based Categorical Eligibility/i);
+  });
+});
+
+describe('checkMedicaid', () => {
+  it('covers eligible adults in expansion states up to 138% FPL', () => {
+    const r = checkMedicaid(inputs({ state: 'OH', grossIncome: 20_000, kids: 0 }));
+    expect(r.eligible).toBe(true);
+    expect(r.monthlyBenefit).toBe(800);
+    expect(r.policyNote).toMatch(/expanded Medicaid/i);
+  });
+
+  it('cuts off at 138% FPL in expansion states', () => {
+    // 3-person FPL = $27,320; 138% = $37,701. $80K is well above.
+    const r = checkMedicaid(inputs({ state: 'OH', grossIncome: 80_000 }));
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/138% FPL/);
+  });
+
+  it('childless adults in non-expansion states are in the coverage gap regardless of income', () => {
+    const r = checkMedicaid(inputs({ state: 'TX', grossIncome: 5_000, kids: 0 }));
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/no Medicaid pathway/i);
+    expect(r.policyNote).toMatch(/coverage gap/i);
+  });
+
+  it('parents in non-expansion states qualify only below the state-specific threshold', () => {
+    // TX parent limit = 17% FPL. 3-person 100% FPL = $27,320 → 17% ≈ $4,644.
+    const eligible = checkMedicaid(inputs({ state: 'TX', grossIncome: 3_000, kids: 1 }));
+    expect(eligible.eligible).toBe(true);
+    const ineligible = checkMedicaid(inputs({ state: 'TX', grossIncome: 30_000, kids: 1 }));
+    expect(ineligible.eligible).toBe(false);
+  });
+});
+
+describe('checkChip', () => {
+  it('is ineligible when there are no kids in the household', () => {
+    const r = checkChip(inputs({ kids: 0 }));
+    expect(r.eligible).toBe(false);
+    expect(r.reason).toMatch(/no kids/i);
+  });
+
+  it("monthly benefit isolates the kids' share of the family premium", () => {
+    // 1 adult + kids: kidsShare = family − single = 800 − 350 = 450.
+    const r = checkChip(
+      inputs({ adults: 1, monthlyHealthcareCost: 800, monthlyHealthcareSingle: 350 }),
+    );
+    expect(r.eligible).toBe(true);
+    expect(r.monthlyBenefit).toBe(450);
+  });
+
+  it('uses 2× single-coverage as the adult baseline for two-adult households', () => {
+    // 2 adults: kidsShare = 1200 − 2*400 = 400.
+    const r = checkChip(
+      inputs({ adults: 2, monthlyHealthcareCost: 1200, monthlyHealthcareSingle: 400 }),
+    );
+    expect(r.monthlyBenefit).toBe(400);
+  });
+
+  it('floors the benefit at zero if family premium is below the adult baseline', () => {
+    const r = checkChip(
+      inputs({ adults: 2, monthlyHealthcareCost: 500, monthlyHealthcareSingle: 400 }),
+    );
+    expect(r.monthlyBenefit).toBe(0);
+  });
+});
+
+describe('checkBenefit dispatch', () => {
+  it('routes by id', () => {
+    const i = inputs();
+    expect(checkBenefit('snap', i)).toEqual(checkSnap(i));
+    expect(checkBenefit('medicaid', i)).toEqual(checkMedicaid(i));
+    expect(checkBenefit('chip', i)).toEqual(checkChip(i));
+  });
+});

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { computeBudget } from '@/lib/budget';
+import type { BudgetInput } from '@/types';
+
+function input(overrides: Partial<BudgetInput> = {}): BudgetInput {
+  return {
+    incomeA: 75_000,
+    filing: 'single',
+    city: 'cmh',
+    kids: 0,
+    lifestyle: 'moderate',
+    ...overrides,
+  };
+}
+
+const sumValues = (rec: Record<string, number>) => Object.values(rec).reduce((s, n) => s + n, 0);
+
+describe('computeBudget — invariants', () => {
+  it('netIncome = grossIncome − totalTaxes', () => {
+    const r = computeBudget(input({ incomeA: 100_000 }));
+    expect(r.netIncome).toBeCloseTo(r.grossIncome - r.totalTaxes);
+  });
+
+  it('totalExpenses equals the sum of the line items', () => {
+    const r = computeBudget(input());
+    expect(r.totalExpenses).toBeCloseTo(sumValues(r.expenses));
+  });
+
+  it('discretionary = monthlyNet − totalExpenses', () => {
+    const r = computeBudget(input());
+    expect(r.discretionary).toBeCloseTo(r.monthlyNet - r.totalExpenses);
+  });
+
+  it('annualDiscretionary is exactly 12× discretionary', () => {
+    const r = computeBudget(input());
+    expect(r.annualDiscretionary).toBeCloseTo(r.discretionary * 12);
+  });
+
+  it('hasPartner is what controls household adults, not income', () => {
+    const partnerNoIncome = computeBudget(input({ hasPartner: true }));
+    const noPartnerNoIncome = computeBudget(input({ hasPartner: false }));
+    expect(partnerNoIncome.adults).toBe(2);
+    expect(noPartnerNoIncome.adults).toBe(1);
+    expect(partnerNoIncome.householdSize).toBe(2);
+  });
+
+  it('a partner toggle without income still triggers the family healthcare plan', () => {
+    const solo = computeBudget(input({ hasPartner: false }));
+    const couple = computeBudget(input({ hasPartner: true }));
+    expect(couple.expenses.Healthcare).toBeGreaterThan(solo.expenses.Healthcare);
+  });
+});
+
+describe('computeBudget — tax math wiring', () => {
+  it('FICA is computed per-person — two earners pay more SS than one combined', () => {
+    const dual = computeBudget(
+      input({ incomeA: 200_000, incomeB: 200_000, hasPartner: true, filing: 'married' }),
+    );
+    const solo = computeBudget(input({ incomeA: 400_000, filing: 'married' }));
+    expect(dual.fica).toBeGreaterThan(solo.fica);
+  });
+
+  it('CTC populates only when there are kids', () => {
+    const noKids = computeBudget(input({ kids: 0 }));
+    const withKids = computeBudget(input({ kids: 2, incomeA: 80_000 }));
+    expect(noKids.ctc).toBe(0);
+    expect(withKids.ctc).toBeGreaterThan(0);
+  });
+
+  it('low-income family with children can show negative federal tax (refundable credits)', () => {
+    const r = computeBudget(input({ incomeA: 25_000, kids: 2, filing: 'head' }));
+    expect(r.federalTax).toBeLessThan(0);
+  });
+
+  it('marriage penalty: two equal high earners pay more federal tax filing jointly than as two singles', () => {
+    // Above ~$770K combined the MFJ top bracket pinches harder than 2× single.
+    const married = computeBudget(
+      input({ incomeA: 500_000, incomeB: 500_000, filing: 'married', hasPartner: true }),
+    );
+    const cohabitating = computeBudget(
+      input({ incomeA: 500_000, incomeB: 500_000, filing: 'single', hasPartner: true }),
+    );
+    expect(married.federalTax).toBeGreaterThan(cohabitating.federalTax);
+  });
+});
+
+describe('computeBudget — benefits integration', () => {
+  it('claiming SNAP reduces the Groceries line and records the offset', () => {
+    const baseline = computeBudget(input({ incomeA: 18_000, kids: 2, filing: 'head' }));
+    const withSnap = computeBudget(
+      input({ incomeA: 18_000, kids: 2, filing: 'head', claimedBenefits: new Set(['snap']) }),
+    );
+    expect(withSnap.expenses.Groceries).toBeLessThan(baseline.expenses.Groceries);
+    expect(withSnap.benefitsApplied['SNAP']).toBeGreaterThan(0);
+    expect(withSnap.totalBenefits).toBeGreaterThan(0);
+  });
+
+  it('Medicaid takes priority over CHIP when both are claimed and the household qualifies', () => {
+    // Low income, kids, expansion state (cmh = OH) → Medicaid covers the household.
+    const r = computeBudget(
+      input({
+        incomeA: 18_000,
+        kids: 2,
+        filing: 'head',
+        claimedBenefits: new Set(['medicaid', 'chip']),
+      }),
+    );
+    expect(r.benefitsApplied['Medicaid']).toBeGreaterThan(0);
+    expect(r.benefitsApplied['CHIP']).toBeUndefined();
+    expect(r.expenses.Healthcare).toBe(0);
+  });
+
+  it('claiming a benefit you do not qualify for has no effect', () => {
+    // High-income household claiming SNAP — must not get the benefit.
+    const r = computeBudget(
+      input({ incomeA: 250_000, kids: 0, claimedBenefits: new Set(['snap']) }),
+    );
+    expect(r.benefitsApplied['SNAP']).toBeUndefined();
+    expect(r.totalBenefits).toBe(0);
+  });
+});

--- a/src/lib/configShare.test.ts
+++ b/src/lib/configShare.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULTS_V1,
+  decodeConfig,
+  encodeConfig,
+  looksLikeConfigHash,
+  type SharedConfig,
+} from '@/lib/configShare';
+
+function clone(cfg: SharedConfig): SharedConfig {
+  return { ...cfg, claimedBenefits: new Set(cfg.claimedBenefits) };
+}
+
+describe('encodeConfig', () => {
+  it('emits only the schema version when config matches all defaults', () => {
+    expect(encodeConfig(clone(DEFAULTS_V1))).toBe('v=1');
+  });
+
+  it('omits keys whose values still match the v=1 default', () => {
+    const cfg = clone(DEFAULTS_V1);
+    cfg.incomeA = 75_000;
+    const params = new URLSearchParams(encodeConfig(cfg));
+    expect(params.get('a')).toBe('75000');
+    expect(params.has('b')).toBe(false);
+    expect(params.has('f')).toBe(false);
+  });
+
+  it('encodes claimed benefits as a sorted comma list', () => {
+    const cfg = clone(DEFAULTS_V1);
+    cfg.claimedBenefits = new Set(['snap', 'medicaid']);
+    const params = new URLSearchParams(encodeConfig(cfg));
+    expect(params.get('cb')).toBe('medicaid,snap');
+  });
+});
+
+describe('decodeConfig', () => {
+  it('round-trips a fully customized config', () => {
+    const original: SharedConfig = {
+      incomeA: 125_000,
+      incomeB: 0,
+      twoIncome: false,
+      filing: 'head',
+      city: 'sf',
+      kids: 1,
+      lifestyle: 'comfortable',
+      compareCity: 'cmh',
+      claimedBenefits: new Set(['chip']),
+    };
+    const decoded = decodeConfig(encodeConfig(original));
+    expect(decoded).toEqual(original);
+  });
+
+  it('falls back to defaults for missing keys', () => {
+    const decoded = decodeConfig('v=1');
+    expect(decoded).toEqual(clone(DEFAULTS_V1));
+    // Defensive: decoded set must be a fresh instance, not the frozen default.
+    expect(decoded.claimedBenefits).not.toBe(DEFAULTS_V1.claimedBenefits);
+  });
+
+  it('ignores unknown filing/lifestyle codes instead of crashing', () => {
+    // Crafted hash like `f=toString` would walk Object.prototype if `in` were
+    // used instead of Object.hasOwn — and `out.filing` would silently become
+    // `Object.prototype.toString`. The guard prevents that; decode should
+    // simply leave `filing` at the default.
+    const decoded = decodeConfig('v=1&f=toString&l=hasOwnProperty');
+    expect(decoded.filing).toBe(DEFAULTS_V1.filing);
+    expect(decoded.lifestyle).toBe(DEFAULTS_V1.lifestyle);
+  });
+
+  it('drops invalid city ids but keeps valid ones', () => {
+    const decoded = decodeConfig('v=1&c=not-a-real-city');
+    expect(decoded.city).toBe(DEFAULTS_V1.city);
+    const decoded2 = decodeConfig('v=1&c=sf');
+    expect(decoded2.city).toBe('sf');
+  });
+
+  it('clamps invalid kid counts (negative, non-numeric, too large)', () => {
+    expect(decodeConfig('v=1&k=-1').kids).toBe(DEFAULTS_V1.kids);
+    expect(decodeConfig('v=1&k=abc').kids).toBe(DEFAULTS_V1.kids);
+    expect(decodeConfig('v=1&k=99').kids).toBe(DEFAULTS_V1.kids);
+    expect(decodeConfig('v=1&k=4').kids).toBe(4);
+  });
+
+  it('strips unknown benefit ids from the cb list', () => {
+    const decoded = decodeConfig('v=1&cb=snap,not-a-program,medicaid');
+    expect(decoded.claimedBenefits).toEqual(new Set(['snap', 'medicaid']));
+  });
+
+  it('accepts a leading # on the payload', () => {
+    const decoded = decodeConfig('#v=1&a=42');
+    expect(decoded.incomeA).toBe(42);
+  });
+});
+
+describe('looksLikeConfigHash', () => {
+  it('recognizes any of the known config keys', () => {
+    expect(looksLikeConfigHash('v=1')).toBe(true);
+    expect(looksLikeConfigHash('a=50000')).toBe(true);
+    expect(looksLikeConfigHash('#cc=sf')).toBe(true);
+  });
+
+  it('rejects empty payloads and unrelated hashes', () => {
+    expect(looksLikeConfigHash('')).toBe(false);
+    expect(looksLikeConfigHash('#')).toBe(false);
+    expect(looksLikeConfigHash('section-name')).toBe(false);
+  });
+});

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -25,7 +25,7 @@ describe('fmt', () => {
 });
 
 describe('fmtSigned', () => {
-  it('always shows a sign on positives', () => {
+  it('prefixes negatives with the typographic minus; positives get no explicit sign', () => {
     expect(fmtSigned(500)).toBe('$500');
     expect(fmtSigned(-500)).toBe(`${MINUS}$500`);
   });

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { fmt, fmtPct, fmtSigned } from '@/lib/format';
+
+// U+2212 MINUS SIGN — typographic correctness, not ASCII hyphen-minus.
+const MINUS = '−';
+
+describe('fmt', () => {
+  it('formats positive integers with $ and grouping commas', () => {
+    expect(fmt(1234)).toBe('$1,234');
+    expect(fmt(1_000_000)).toBe('$1,000,000');
+  });
+
+  it('rounds to the nearest dollar', () => {
+    expect(fmt(1234.4)).toBe('$1,234');
+    expect(fmt(1234.6)).toBe('$1,235');
+  });
+
+  it('formats zero as $0 (no sign)', () => {
+    expect(fmt(0)).toBe('$0');
+  });
+
+  it('uses a real minus sign for negatives, not a hyphen', () => {
+    expect(fmt(-1234)).toBe(`${MINUS}$1,234`);
+  });
+});
+
+describe('fmtSigned', () => {
+  it('always shows a sign on positives', () => {
+    expect(fmtSigned(500)).toBe('$500');
+    expect(fmtSigned(-500)).toBe(`${MINUS}$500`);
+  });
+
+  it('rounds before formatting', () => {
+    expect(fmtSigned(99.6)).toBe('$100');
+    expect(fmtSigned(-99.6)).toBe(`${MINUS}$100`);
+  });
+});
+
+describe('fmtPct', () => {
+  it('takes a fraction and renders one decimal', () => {
+    expect(fmtPct(0.123)).toBe('12.3%');
+    expect(fmtPct(1)).toBe('100.0%');
+    expect(fmtPct(0)).toBe('0.0%');
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -5,7 +5,12 @@ export function fmt(n: number): string {
   return '$' + r.toLocaleString();
 }
 
-/** Always shows the sign; useful for deltas and discretionary amounts. */
+/**
+ * Currently equivalent to `fmt`: typographic minus for negatives, no explicit
+ * '+' for positives. Kept as a separate name so call sites that handle
+ * potentially-negative deltas (discretionary income, comparisons) read
+ * intentionally — and so a future "+" prefix can land here without churn.
+ */
 export function fmtSigned(n: number): string {
   return (n < 0 ? '−$' : '$') + Math.abs(Math.round(n)).toLocaleString();
 }

--- a/src/lib/tax.test.ts
+++ b/src/lib/tax.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bracketBreakdown,
+  calcChildTaxCredit,
+  calcEITC,
+  calcFICA,
+  progressiveTax,
+} from '@/lib/tax';
+import { FEDERAL_BRACKETS_2026, SS_WAGE_BASE } from '@/data/federalTax';
+import type { TaxBracket } from '@/types';
+
+const SAMPLE_BRACKETS: readonly TaxBracket[] = [
+  [10_000, 0.1],
+  [50_000, 0.2],
+  [Infinity, 0.3],
+];
+
+describe('progressiveTax', () => {
+  it('returns 0 for non-positive income', () => {
+    expect(progressiveTax(0, SAMPLE_BRACKETS)).toBe(0);
+    expect(progressiveTax(-5000, SAMPLE_BRACKETS)).toBe(0);
+  });
+
+  it('only taxes dollars within each bracket at that bracket rate', () => {
+    expect(progressiveTax(5_000, SAMPLE_BRACKETS)).toBeCloseTo(500);
+    expect(progressiveTax(10_000, SAMPLE_BRACKETS)).toBeCloseTo(1_000);
+    expect(progressiveTax(30_000, SAMPLE_BRACKETS)).toBeCloseTo(1_000 + 20_000 * 0.2);
+    expect(progressiveTax(50_000, SAMPLE_BRACKETS)).toBeCloseTo(1_000 + 40_000 * 0.2);
+    expect(progressiveTax(100_000, SAMPLE_BRACKETS)).toBeCloseTo(1_000 + 8_000 + 50_000 * 0.3);
+  });
+
+  it('matches a hand-computed value against real 2026 single brackets', () => {
+    // $80k taxable, single, 2026:
+    //   12,400 × 10%        =  1,240
+    //   (50,400 − 12,400) × 12% = 4,560
+    //   (80,000 − 50,400) × 22% = 6,512
+    //   total = 12,312
+    expect(progressiveTax(80_000, FEDERAL_BRACKETS_2026.single)).toBeCloseTo(12_312);
+  });
+});
+
+describe('bracketBreakdown', () => {
+  it('sum of taxFromRow equals progressiveTax', () => {
+    const taxable = 75_000;
+    const rows = bracketBreakdown(taxable, FEDERAL_BRACKETS_2026.married);
+    const summed = rows.reduce((acc, r) => acc + r.taxFromRow, 0);
+    expect(summed).toBeCloseTo(progressiveTax(taxable, FEDERAL_BRACKETS_2026.married));
+  });
+
+  it('marks exactly one bracket as the user bracket when income lands inside one', () => {
+    const rows = bracketBreakdown(75_000, FEDERAL_BRACKETS_2026.married);
+    const flagged = rows.filter((r) => r.isUserBracket);
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].rate).toBe(0.12); // 75k MFJ → 12% bracket
+  });
+
+  it('produces zero-fill rows when taxable income is 0 and marks no user bracket', () => {
+    const rows = bracketBreakdown(0, SAMPLE_BRACKETS);
+    expect(rows).toHaveLength(SAMPLE_BRACKETS.length);
+    expect(rows.every((r) => r.taxableInRow === 0)).toBe(true);
+    expect(rows.some((r) => r.isUserBracket)).toBe(false);
+  });
+});
+
+describe('calcFICA', () => {
+  it('is zero on zero income', () => {
+    expect(calcFICA(0)).toBe(0);
+  });
+
+  it('caps Social Security at the wage base, but Medicare keeps going', () => {
+    // At exactly the wage base: SS = wage_base × 6.2%, Medicare = wage_base × 1.45%
+    const expectedAtCap = SS_WAGE_BASE * 0.062 + SS_WAGE_BASE * 0.0145;
+    expect(calcFICA(SS_WAGE_BASE)).toBeCloseTo(expectedAtCap);
+
+    // Above the cap, SS stays flat, Medicare grows. Stay below $200K so
+    // additional-Medicare doesn't muddy the assertion (covered separately).
+    const above = SS_WAGE_BASE + 10_000; // 184,500 + 10,000 = 194,500 < 200K
+    const expectedAbove = SS_WAGE_BASE * 0.062 + above * 0.0145;
+    expect(calcFICA(above)).toBeCloseTo(expectedAbove);
+  });
+
+  it('applies additional Medicare 0.9% on income above $200K', () => {
+    const income = 250_000;
+    const ss = SS_WAGE_BASE * 0.062;
+    const medicare = income * 0.0145;
+    const addl = (income - 200_000) * 0.009;
+    expect(calcFICA(income)).toBeCloseTo(ss + medicare + addl);
+  });
+
+  it('two earners pay more SS than one earner with the same combined income', () => {
+    // The whole point of the per-person wage base. $200K + $200K should pay
+    // strictly more than a single $400K filer.
+    const split = calcFICA(200_000) + calcFICA(200_000);
+    const lumped = calcFICA(400_000);
+    expect(split).toBeGreaterThan(lumped);
+  });
+});
+
+describe('calcChildTaxCredit', () => {
+  it('returns 0 when there are no kids', () => {
+    expect(calcChildTaxCredit(50_000, 0, 'single')).toBe(0);
+    expect(calcChildTaxCredit(500_000, 0, 'married')).toBe(0);
+  });
+
+  it('returns full $2,000 per kid below the phase-out threshold', () => {
+    expect(calcChildTaxCredit(100_000, 2, 'single')).toBe(4_000);
+    expect(calcChildTaxCredit(300_000, 3, 'married')).toBe(6_000);
+  });
+
+  it('phases out by $50 per $1,000 over $200K (single) / $400K (married)', () => {
+    // Single, 1 kid, $210K → over by $10K → 10 × $50 = $500 reduction
+    expect(calcChildTaxCredit(210_000, 1, 'single')).toBe(2_000 - 500);
+    // Married, 1 kid, $410K → over by $10K → $500 reduction
+    expect(calcChildTaxCredit(410_000, 1, 'married')).toBe(2_000 - 500);
+  });
+
+  it('floors at zero when the phase-out fully exhausts the credit', () => {
+    expect(calcChildTaxCredit(1_000_000, 1, 'single')).toBe(0);
+  });
+});
+
+describe('calcEITC', () => {
+  it('is zero above the upper income gate', () => {
+    expect(calcEITC(75_000, 2, 'married')).toBe(0);
+    expect(calcEITC(100_000, 0, 'single')).toBe(0);
+  });
+
+  it('is zero at zero income', () => {
+    expect(calcEITC(0, 2, 'single')).toBe(0);
+  });
+
+  it('hits the plateau max at the documented amount', () => {
+    // 2 kids, single: max 7,316; plateau begins at end of phase-in (18,500)
+    // and runs through phase-out start (23,700). $20K is squarely on the plateau.
+    expect(calcEITC(20_000, 2, 'single')).toBeCloseTo(7_316);
+  });
+
+  it('phases out linearly to zero', () => {
+    // 1 kid, single, phaseOutEnd = 50,000 → just above should be zero
+    expect(calcEITC(50_000, 1, 'single')).toBeCloseTo(0);
+    // Halfway through the phase-out should be roughly half the max
+    const max = 4_427;
+    const phaseOutStart = 23_700;
+    const phaseOutEnd = 50_000;
+    const mid = (phaseOutStart + phaseOutEnd) / 2;
+    expect(calcEITC(mid, 1, 'single')).toBeCloseTo(max / 2, 0);
+  });
+
+  it('married households get higher phase-out thresholds (marriage bonus at the bottom)', () => {
+    // Same low-mid income, 2 kids: married should get >= single because
+    // the phase-out doesn't kick in as early.
+    expect(calcEITC(35_000, 2, 'married')).toBeGreaterThan(calcEITC(35_000, 2, 'single'));
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
@@ -5,6 +6,11 @@ import { fileURLToPath, URL } from 'node:url';
 export default defineConfig({
   plugins: [react()],
   base: './', // works for static hosts and GitHub Pages out of the box
+  // Vitest reads this same config; tests are colocated as `*.test.ts` next
+  // to the source they cover. Pure-function libs only — no jsdom needed.
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
   server: {
     host: true,
     port: 5173,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,8 @@
-/// <reference types="vitest" />
-import { defineConfig } from 'vite';
+// Use vitest/config so the `test` key is typed without depending on a
+// triple-slash directive (tsconfig.node.json has an explicit `types` array
+// that suppresses ambient lookups). vitest/config re-exports vite's
+// defineConfig with the test field merged in.
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -382,7 +382,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -563,7 +563,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -583,6 +583,16 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
   languageName: node
   linkType: hard
 
@@ -655,6 +665,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
 "@types/esrecurse@npm:^4.3.1":
   version: 4.3.1
   resolution: "@types/esrecurse@npm:4.3.1"
@@ -662,7 +679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -863,6 +880,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/expect@npm:4.1.5"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/5184682304db471aa20024c1154210ad3d6d590afb61646201ce1a15297259f9a35f92f8fad4435bc8a82135e307ddd27c8495f72417d72d9aa139eb281d9e06
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/mocker@npm:4.1.5"
+  dependencies:
+    "@vitest/spy": "npm:4.1.5"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/bcfe97700476130933c7ea33fa670c8d2768a81de5325ce407f901e55c2f66cabbb88a7b6cffb46ddf33dff7d8fc209d769fb298f568e310fbeead9b36f6fdb9
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/pretty-format@npm:4.1.5"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/42b5e9b75e87c0a884d36bee364e2d07ee45e96f413377737a74993e077d90c3a12aa36743855aee5e4e28b78fae20e3e6de5eef8d5344b9aba2bc1e1d5537a1
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/runner@npm:4.1.5"
+  dependencies:
+    "@vitest/utils": "npm:4.1.5"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/6a03b313a121155f6dd9e32eeb103c0e12440f586bc4ba1f0d77444e44c6df4652a44443718552037463115635b8378e11f35902d90ce1326f77743219fca056
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/snapshot@npm:4.1.5"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e11bf50d06702331290750a40eaef86078c108df3cd9a52bb1be7b84250048790163f36827525be6a383a4bb1994fc35e6d0c24239a41688b0bb68a1d15d172f
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/spy@npm:4.1.5"
+  checksum: 10c0/fda6b1ee0a2fec1a152d8041aba7a79744c3876863b244d1ed406d02b36e8ccc997edb2e3963d1027d728d3dc5a33813e11bef53a0a14fc7de4de5e721d0f591
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/utils@npm:4.1.5"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.5"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/72409717e68018e5fe42fa173cc4eff6def8c35bd52013f86ddb414cd28d73fcc425ac62968e01a52371b3fd5a7a775536283d2f1d64432753f628712a6a4908
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -897,6 +996,13 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/67966499dd272ecde1c2e467084411132891523d057487587879d39ac04207f4351b7b2324c83198013967fbfa632c1612adc960114a30770fbe07a0773b32c2
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -964,6 +1070,7 @@ __metadata:
     typescript: "npm:^6.0.3"
     typescript-eslint: "npm:^8.59.1"
     vite: "npm:^8.0.10"
+    vitest: "npm:^4.1.5"
   languageName: unknown
   linkType: soft
 
@@ -971,6 +1078,13 @@ __metadata:
   version: 1.0.30001791
   resolution: "caniuse-lite@npm:1.0.30001791"
   checksum: 10c0/53c8b5dad1c196a5e495405a7d2dc1db58aed9be02f60cf2a2e29d2c8d8cbb6c39beabf958d6aa191ab967ddcf49f22319452256b980bad1e271615acfe58940
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -1153,6 +1267,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "es-module-lexer@npm:2.1.0"
+  checksum: 10c0/93bcf2454fa72d67fe3ccd0abef8ce7933f5840a319513418a643dd8e9c6aa8f49709cecfae02ded722805dd327232d30723a807cc52e6809d6ac697c62c29fb
+  languageName: node
+  linkType: hard
+
 "es-toolkit@npm:^1.39.3":
   version: 1.46.1
   resolution: "es-toolkit@npm:1.46.1"
@@ -1321,6 +1442,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -1332,6 +1462,13 @@ __metadata:
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -1744,6 +1881,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.21":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
@@ -1830,6 +1976,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "obug@npm:2.1.1"
+  checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.9.3":
   version: 0.9.4
   resolution: "optionator@npm:0.9.4"
@@ -1876,6 +2029,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -1883,7 +2043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -2120,10 +2280,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
   languageName: node
   linkType: hard
 
@@ -2147,6 +2328,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.1.2
+  resolution: "tinyexec@npm:1.1.2"
+  checksum: 10c0/9e0ef6c001ce54688cf16833a02f70a339276219ca947b88930b124267de2cffc764ff44e87e7369384b1d75ab63491465412cbbdf06f2437956b9ab66ab4491
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
   version: 0.2.16
   resolution: "tinyglobby@npm:0.2.16"
@@ -2154,6 +2349,13 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -2285,7 +2487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^8.0.10":
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.0.10":
   version: 8.0.10
   resolution: "vite@npm:8.0.10"
   dependencies:
@@ -2342,6 +2544,74 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "vitest@npm:4.1.5"
+  dependencies:
+    "@vitest/expect": "npm:4.1.5"
+    "@vitest/mocker": "npm:4.1.5"
+    "@vitest/pretty-format": "npm:4.1.5"
+    "@vitest/runner": "npm:4.1.5"
+    "@vitest/snapshot": "npm:4.1.5"
+    "@vitest/spy": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.5
+    "@vitest/browser-preview": 4.1.5
+    "@vitest/browser-webdriverio": 4.1.5
+    "@vitest/coverage-istanbul": 4.1.5
+    "@vitest/coverage-v8": 4.1.5
+    "@vitest/ui": 4.1.5
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/196eaf5e95b45a3f6d3001a2408d7dc6f146c29c873ed4e42e1ad4c9327122934fb3793a12b6ce3b7c25d355e738b20123acc0894ce30358c3370b15f4bd0865
+  languageName: node
+  linkType: hard
+
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -2361,6 +2631,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Adds Vitest (reads `vite.config.ts` directly, `@/` alias works for free)
- Adds 65 unit tests across the five pure-function modules in `src/lib/`:
  - **tax.ts** — progressive brackets, FICA per-person cap, CTC phase-out, EITC piecewise
  - **format.ts** — locks in the U+2212 minus convention
  - **configShare.ts** — round-trip, default omission, **prototype-pollution regression test** (so nobody undoes the `Object.hasOwn` guard)
  - **benefits.ts** — SNAP/Medicaid/CHIP including expansion vs non-expansion paths and the coverage gap
  - **budget.ts** — invariants (`net = gross − totalTaxes`, expense sum, discretionary identity) plus integration spot-checks (marriage penalty, refundable credits going negative, SNAP/Medicaid offsets, Medicaid-over-CHIP priority)
- Adds `yarn test` (and `yarn test:watch`)
- Adds `test` to the CI matrix as its own status line, alongside lint/typecheck/format
- `yarn verify` now also runs tests

Style: invariant + spot-check tests over snapshots — chosen so updating a city's rent or a poverty guideline doesn't churn unrelated test files.

Skipped: `lib/nav.ts` (20 lines of DOM glue), `lib/sourceStatus.tsx` (UI-adjacent).

## Test plan
- [ ] `yarn test` passes locally (65 tests)
- [ ] CI shows a new `test` status line and it passes
- [ ] `yarn verify` runs end-to-end including the new test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)