### PR TITLE
Add pinned exact-value regressions to computeBudget

### DIFF
--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -127,7 +127,9 @@ describe('computeBudget — benefits integration', () => {
  */
 describe('computeBudget — pinned regressions', () => {
   it('low-income HoH with 2 kids in Columbus: refundable credits drive negative federal tax', () => {
-    const r = computeBudget(input({ incomeA: 25_000, filing: 'head', city: 'cmh', kids: 2, lifestyle: 'modest' }));
+    const r = computeBudget(
+      input({ incomeA: 25_000, filing: 'head', city: 'cmh', kids: 2, lifestyle: 'modest' }),
+    );
     expect(Math.round(r.federalTax)).toBe(-10_422); // CTC $4,000 + EITC $7,022, raw fed ~$600
     expect(Math.round(r.ctc)).toBe(4_000);
     expect(Math.round(r.eitc)).toBe(7_022);
@@ -137,7 +139,9 @@ describe('computeBudget — pinned regressions', () => {
   });
 
   it('median single in Columbus: standard middle-class profile', () => {
-    const r = computeBudget(input({ incomeA: 75_000, filing: 'single', city: 'cmh', kids: 0, lifestyle: 'moderate' }));
+    const r = computeBudget(
+      input({ incomeA: 75_000, filing: 'single', city: 'cmh', kids: 0, lifestyle: 'moderate' }),
+    );
     expect(Math.round(r.federalTax)).toBe(7_670);
     expect(Math.round(r.stateTax)).toBe(1_346);
     expect(Math.round(r.fica)).toBe(5_738);
@@ -146,14 +150,21 @@ describe('computeBudget — pinned regressions', () => {
   });
 
   it('dual-earner $200K+$200K married in NYC with 2 kids: per-person FICA + city tax', () => {
-    const r = computeBudget(input({
-      incomeA: 200_000, incomeB: 200_000, hasPartner: true,
-      filing: 'married', city: 'nyc', kids: 2, lifestyle: 'comfortable',
-    }));
+    const r = computeBudget(
+      input({
+        incomeA: 200_000,
+        incomeB: 200_000,
+        hasPartner: true,
+        filing: 'married',
+        city: 'nyc',
+        kids: 2,
+        lifestyle: 'comfortable',
+      }),
+    );
     expect(Math.round(r.federalTax)).toBe(69_468);
     expect(Math.round(r.stateTax)).toBe(22_413);
     expect(Math.round(r.localTax)).toBe(15_200); // NYC local tax
-    expect(Math.round(r.fica)).toBe(28_678);     // two SS wage bases
+    expect(Math.round(r.fica)).toBe(28_678); // two SS wage bases
     expect(Math.round(r.totalTaxes)).toBe(135_759);
   });
 });

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -119,3 +119,41 @@ describe('computeBudget — benefits integration', () => {
     expect(r.totalBenefits).toBe(0);
   });
 });
+
+/**
+ * Pinned exact-value regressions across the income spectrum. Update these
+ * deliberately when tax brackets, credit amounts, or cost-of-living tables
+ * change for a new year — the diff documents what moved and why.
+ */
+describe('computeBudget — pinned regressions', () => {
+  it('low-income HoH with 2 kids in Columbus: refundable credits drive negative federal tax', () => {
+    const r = computeBudget(input({ incomeA: 25_000, filing: 'head', city: 'cmh', kids: 2, lifestyle: 'modest' }));
+    expect(Math.round(r.federalTax)).toBe(-10_422); // CTC $4,000 + EITC $7,022, raw fed ~$600
+    expect(Math.round(r.ctc)).toBe(4_000);
+    expect(Math.round(r.eitc)).toBe(7_022);
+    expect(Math.round(r.fica)).toBe(1_913);
+    expect(Math.round(r.totalTaxes)).toBe(-7_884);
+    expect(Math.round(r.netIncome)).toBe(32_884);
+  });
+
+  it('median single in Columbus: standard middle-class profile', () => {
+    const r = computeBudget(input({ incomeA: 75_000, filing: 'single', city: 'cmh', kids: 0, lifestyle: 'moderate' }));
+    expect(Math.round(r.federalTax)).toBe(7_670);
+    expect(Math.round(r.stateTax)).toBe(1_346);
+    expect(Math.round(r.fica)).toBe(5_738);
+    expect(Math.round(r.totalTaxes)).toBe(16_629);
+    expect(Math.round(r.netIncome)).toBe(58_371);
+  });
+
+  it('dual-earner $200K+$200K married in NYC with 2 kids: per-person FICA + city tax', () => {
+    const r = computeBudget(input({
+      incomeA: 200_000, incomeB: 200_000, hasPartner: true,
+      filing: 'married', city: 'nyc', kids: 2, lifestyle: 'comfortable',
+    }));
+    expect(Math.round(r.federalTax)).toBe(69_468);
+    expect(Math.round(r.stateTax)).toBe(22_413);
+    expect(Math.round(r.localTax)).toBe(15_200); // NYC local tax
+    expect(Math.round(r.fica)).toBe(28_678);     // two SS wage bases
+    expect(Math.round(r.totalTaxes)).toBe(135_759);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `pinned regressions` block to `src/lib/budget.test.ts` covering three representative households across the income spectrum with exact-value `toBe` assertions:

- **Low-income HoH with 2 kids in Columbus** — refundable credits (CTC + EITC) drive federal tax negative.
- **Median single in Columbus** — standard middle-class profile, sanity-checks the typical case.
- **Dual-earner \$200K + \$200K married in NYC with 2 kids** — exercises per-person FICA, NYC local tax, and the high-bracket federal math.

The point is to document the intended numbers explicitly so a tax-year update (or accidental tweak) produces a meaningful, reviewable diff rather than silent drift. Complements the existing invariant tests, which check relationships rather than exact values.

## Test plan

- [ ] `yarn test` — 68 tests pass locally
- [ ] `yarn typecheck` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)