### PR TITLE
Add income-sweep cliff curve

### DIFF
--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -304,26 +304,7 @@ function Card({
         <EligibilityBadge eligible={eligible} claimed={claimed} phantomEligible={phantomEligible} />
       </div>
 
-      {recommendedOverChip && !claimed && (
-        <div
-          style={{
-            display: 'inline-block',
-            fontSize: rem(10),
-            letterSpacing: '0.14em',
-            textTransform: 'uppercase',
-            color: T.positive,
-            background: 'rgba(45, 80, 22, 0.1)',
-            border: `1px solid ${T.positive}`,
-            padding: '3px 8px',
-            borderRadius: 2,
-            fontWeight: 600,
-            marginBottom: 8,
-          }}
-          title="When both Medicaid and CHIP are available, Medicaid is the better choice — it covers the whole household (kids included) at $0 cost with broader benefits than CHIP. Claiming Medicaid will automatically uncheck CHIP."
-        >
-          ★ Better option than CHIP
-        </div>
-      )}
+      {recommendedOverChip && !claimed && <BetterOptionBadge />}
 
       <div
         style={{
@@ -564,6 +545,101 @@ function ValueWithDerivation({
             How this is computed
           </div>
           {derivation}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Small green badge that appears on the Medicaid card when CHIP is also
+ *  eligible. Hover/focus reveals a popover explaining WHY Medicaid is the
+ *  better choice — covers the whole household at $0 cost with broader
+ *  benefits, plus the practical UX note that claiming Medicaid will
+ *  auto-drop CHIP. */
+function BetterOptionBadge() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ position: 'relative', display: 'inline-block', marginBottom: 8 }}>
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        aria-describedby={open ? 'better-option-popover' : undefined}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          display: 'inline-block',
+          fontSize: rem(10),
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: T.positive,
+          background: 'rgba(45, 80, 22, 0.1)',
+          border: `1px solid ${T.positive}`,
+          padding: '3px 8px',
+          borderRadius: 2,
+          fontWeight: 600,
+          cursor: 'help',
+          fontFamily: fonts.body,
+        }}
+      >
+        ★ Better option than CHIP
+      </button>
+      {open && (
+        <div
+          id="better-option-popover"
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            left: 0,
+            zIndex: 5,
+            width: 320,
+            padding: '10px 12px',
+            background: T.surface,
+            border: `1px solid ${T.positive}`,
+            borderRadius: 4,
+            boxShadow: '0 4px 12px rgba(27, 24, 21, 0.12)',
+            fontFamily: fonts.body,
+            fontSize: rem(12),
+            lineHeight: 1.5,
+            color: T.ink,
+            fontStyle: 'normal',
+            pointerEvents: 'none',
+            textTransform: 'none',
+            letterSpacing: 'normal',
+          }}
+        >
+          <div
+            style={{
+              fontSize: rem(10),
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: T.inkMuted,
+              fontWeight: 600,
+              marginBottom: 4,
+            }}
+          >
+            Why Medicaid over CHIP
+          </div>
+          <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <li>
+              <strong>Covers the whole household</strong> — adults and kids — instead of just
+              the kids' share.
+            </li>
+            <li>
+              <strong>Genuinely $0 cost.</strong> CHIP often charges small monthly premiums above
+              ~150% FPL (varies by state); Medicaid does not.
+            </li>
+            <li>
+              <strong>Broader benefits.</strong> Medicaid typically has $0 deductible, $0 copay,
+              and includes dental/vision; CHIP varies more by state.
+            </li>
+          </ul>
+          <div style={{ marginTop: 6, color: T.inkMuted, fontSize: rem(11) }}>
+            Claiming Medicaid will automatically uncheck CHIP — the kids are covered either
+            way.
+          </div>
         </div>
       )}
     </div>

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -136,6 +136,12 @@ export function Benefits({
           const sources: readonly Source[] = meta.stateSource
             ? [...baseSources, meta.stateSource(inputs)]
             : baseSources;
+          // Medicaid covers the entire household when claimed (including
+          // kids), so CHIP claimed alongside it would add zero relief —
+          // the budget code skips applying CHIP in that case (see budget.ts).
+          // Surface that here so clicking CHIP doesn't look like a no-op.
+          const overshadowedByMedicaid =
+            meta.id === 'chip' && claimed.has('medicaid') && evaluate('medicaid').eligible;
           return (
             <Card
               key={meta.id}
@@ -143,6 +149,7 @@ export function Benefits({
               sources={sources}
               eligibility={elig}
               claimed={isClaimed}
+              overshadowedByMedicaid={overshadowedByMedicaid}
               onToggle={() => toggle(meta.id)}
             />
           );
@@ -191,12 +198,17 @@ function Card({
   sources,
   eligibility,
   claimed,
+  overshadowedByMedicaid = false,
   onToggle,
 }: {
   meta: BenefitMeta;
   sources: readonly Source[];
   eligibility: BenefitEligibility;
   claimed: boolean;
+  /** CHIP-only: true when Medicaid is claimed and eligible, in which case
+   *  CHIP would add $0 (Medicaid covers kids too). The card surfaces the
+   *  redundancy and disables the claim affordance. */
+  overshadowedByMedicaid?: boolean;
   onToggle: () => void;
 }) {
   const eligible = eligibility.eligible;
@@ -211,7 +223,12 @@ function Card({
   // into the phantom zone, the auto-drop logic in BudgetExplorer won't
   // fire (eligibility is still true), so we must keep the unclaim path
   // open — otherwise the card gets stuck "claimed at $0" forever.
-  const actionable = (eligible && !phantomEligible) || (phantomEligible && claimed);
+  const actionable =
+    // Allow unclaim if the card was claimed before Medicaid took over,
+    // so the user isn't stuck with a misleading "Claimed" badge.
+    (overshadowedByMedicaid && claimed) ||
+    (!overshadowedByMedicaid &&
+      ((eligible && !phantomEligible) || (phantomEligible && claimed)));
   const handleClick = () => {
     if (actionable) onToggle();
   };
@@ -285,7 +302,20 @@ function Card({
         {meta.blurb}
       </div>
 
-      {eligible && eligibility.monthlyBenefit > 0 ? (
+      {overshadowedByMedicaid ? (
+        <div
+          style={{
+            fontSize: rem(12),
+            color: T.inkMuted,
+            lineHeight: 1.5,
+            fontStyle: 'italic',
+          }}
+        >
+          Already covered by Medicaid — when a household qualifies for Medicaid, kids are
+          included in that coverage, so claiming CHIP separately adds nothing. Unclaim Medicaid
+          first if you want to see CHIP's standalone value.
+        </div>
+      ) : eligible && eligibility.monthlyBenefit > 0 ? (
         <>
           <ValueWithDerivation
             value={`~${fmt(eligibility.monthlyBenefit)}/mo`}

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -667,7 +667,7 @@ function OvershadowedByMedicaidNote() {
           fontStyle: 'italic',
         }}
       >
-        🔒 Covered by Medicaid · why?
+        Covered by Medicaid · why?
       </button>
       {open && (
         <div

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -240,8 +240,7 @@ function Card({
     // Allow unclaim if the card was claimed before Medicaid took over,
     // so the user isn't stuck with a misleading "Claimed" badge.
     (overshadowedByMedicaid && claimed) ||
-    (!overshadowedByMedicaid &&
-      ((eligible && !phantomEligible) || (phantomEligible && claimed)));
+    (!overshadowedByMedicaid && ((eligible && !phantomEligible) || (phantomEligible && claimed)));
   const handleClick = () => {
     if (actionable) onToggle();
   };
@@ -611,23 +610,24 @@ function BetterOptionBadge() {
           >
             Why Medicaid over CHIP
           </div>
-          <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <ul
+            style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}
+          >
             <li>
-              <strong>Covers the whole household</strong> — adults and kids — instead of just
-              the kids' share.
+              <strong>Covers the whole household</strong> — adults and kids — instead of just the
+              kids' share.
             </li>
             <li>
               <strong>Genuinely $0 cost.</strong> CHIP often charges small monthly premiums above
               ~150% FPL (varies by state); Medicaid does not.
             </li>
             <li>
-              <strong>Broader benefits.</strong> Medicaid typically has $0 deductible, $0 copay,
-              and includes dental/vision; CHIP varies more by state.
+              <strong>Broader benefits.</strong> Medicaid typically has $0 deductible, $0 copay, and
+              includes dental/vision; CHIP varies more by state.
             </li>
           </ul>
           <div style={{ marginTop: 6, color: T.inkMuted, fontSize: rem(11) }}>
-            Claiming Medicaid will automatically uncheck CHIP — the kids are covered either
-            way.
+            Claiming Medicaid will automatically uncheck CHIP — the kids are covered either way.
           </div>
         </div>
       )}
@@ -705,11 +705,11 @@ function OvershadowedByMedicaidNote() {
           >
             Why CHIP isn't claimable here
           </div>
-          When a household qualifies for Medicaid, the kids are included in that coverage —
-          they're enrolled in Medicaid, not CHIP. CHIP exists for kids in households that earn
-          too much for Medicaid but not enough for affordable private insurance. Since this
-          household is on Medicaid, CHIP would add zero relief. Unclaim Medicaid above if you
-          want to see CHIP's standalone value at this income.
+          When a household qualifies for Medicaid, the kids are included in that coverage — they're
+          enrolled in Medicaid, not CHIP. CHIP exists for kids in households that earn too much for
+          Medicaid but not enough for affordable private insurance. Since this household is on
+          Medicaid, CHIP would add zero relief. Unclaim Medicaid above if you want to see CHIP's
+          standalone value at this income.
         </div>
       )}
     </div>

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -318,18 +318,7 @@ function Card({
       </div>
 
       {overshadowedByMedicaid ? (
-        <div
-          style={{
-            fontSize: rem(12),
-            color: T.inkMuted,
-            lineHeight: 1.5,
-            fontStyle: 'italic',
-          }}
-        >
-          Already covered by Medicaid — when a household qualifies for Medicaid, kids are
-          included in that coverage, so claiming CHIP separately adds nothing. Unclaim Medicaid
-          first if you want to see CHIP's standalone value.
-        </div>
+        <OvershadowedByMedicaidNote />
       ) : eligible && eligibility.monthlyBenefit > 0 ? (
         <>
           <ValueWithDerivation
@@ -640,6 +629,86 @@ function BetterOptionBadge() {
             Claiming Medicaid will automatically uncheck CHIP — the kids are covered either
             way.
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** CHIP-only: shown when Medicaid is claimed and the budget code skips
+ *  applying CHIP (Medicaid covers the household — kids included). The
+ *  visible label is short ("Covered by Medicaid · why?") with a dotted
+ *  underline that opens a richer tooltip on hover/focus explaining the
+ *  policy reality and what to do if the user wants CHIP's standalone
+ *  value back. */
+function OvershadowedByMedicaidNote() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        aria-describedby={open ? 'overshadow-popover' : undefined}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          padding: 0,
+          cursor: 'help',
+          fontFamily: fonts.body,
+          fontSize: rem(12),
+          color: T.inkMuted,
+          textDecoration: 'underline',
+          textDecorationStyle: 'dotted',
+          textUnderlineOffset: 3,
+          fontStyle: 'italic',
+        }}
+      >
+        🔒 Covered by Medicaid · why?
+      </button>
+      {open && (
+        <div
+          id="overshadow-popover"
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            left: 0,
+            zIndex: 5,
+            width: 320,
+            padding: '10px 12px',
+            background: T.surface,
+            border: `1px solid ${T.border}`,
+            borderRadius: 4,
+            boxShadow: '0 4px 12px rgba(27, 24, 21, 0.12)',
+            fontFamily: fonts.body,
+            fontSize: rem(12),
+            lineHeight: 1.5,
+            color: T.ink,
+            fontStyle: 'normal',
+            pointerEvents: 'none',
+          }}
+        >
+          <div
+            style={{
+              fontSize: rem(10),
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: T.inkMuted,
+              fontWeight: 600,
+              marginBottom: 4,
+            }}
+          >
+            Why CHIP isn't claimable here
+          </div>
+          When a household qualifies for Medicaid, the kids are included in that coverage —
+          they're enrolled in Medicaid, not CHIP. CHIP exists for kids in households that earn
+          too much for Medicaid but not enough for affordable private insurance. Since this
+          household is on Medicaid, CHIP would add zero relief. Unclaim Medicaid above if you
+          want to see CHIP's standalone value at this income.
         </div>
       )}
     </div>

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -654,20 +654,21 @@ function OvershadowedByMedicaidNote() {
         aria-describedby={open ? 'overshadow-popover' : undefined}
         onClick={(e) => e.stopPropagation()}
         style={{
-          background: 'transparent',
-          border: 'none',
-          padding: 0,
+          display: 'inline-block',
+          fontSize: rem(10),
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: T.warning,
+          background: 'rgba(184, 116, 43, 0.1)',
+          border: `1px solid ${T.warning}`,
+          padding: '3px 8px',
+          borderRadius: 2,
+          fontWeight: 600,
           cursor: 'help',
           fontFamily: fonts.body,
-          fontSize: rem(12),
-          color: T.inkMuted,
-          textDecoration: 'underline',
-          textDecorationStyle: 'dotted',
-          textUnderlineOffset: 3,
-          fontStyle: 'italic',
         }}
       >
-        Covered by Medicaid · why?
+        ◐ Covered by Medicaid
       </button>
       {open && (
         <div
@@ -681,7 +682,7 @@ function OvershadowedByMedicaidNote() {
             width: 320,
             padding: '10px 12px',
             background: T.surface,
-            border: `1px solid ${T.border}`,
+            border: `1px solid ${T.warning}`,
             borderRadius: 4,
             boxShadow: '0 4px 12px rgba(27, 24, 21, 0.12)',
             fontFamily: fonts.body,

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -250,6 +250,7 @@ function Card({
       <div
         style={{
           display: 'flex',
+          flexWrap: 'wrap',
           justifyContent: 'space-between',
           alignItems: 'baseline',
           marginBottom: 4,

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -142,6 +142,12 @@ export function Benefits({
           // Surface that here so clicking CHIP doesn't look like a no-op.
           const overshadowedByMedicaid =
             meta.id === 'chip' && claimed.has('medicaid') && evaluate('medicaid').eligible;
+          // When both Medicaid and CHIP are eligible, Medicaid is the
+          // strictly better option (covers everyone, $0 cost, broader
+          // benefits). Flag the Medicaid card so the user doesn't pick
+          // CHIP-only by mistake.
+          const recommendedOverChip =
+            meta.id === 'medicaid' && elig.eligible && evaluate('chip').eligible;
           return (
             <Card
               key={meta.id}
@@ -150,6 +156,7 @@ export function Benefits({
               eligibility={elig}
               claimed={isClaimed}
               overshadowedByMedicaid={overshadowedByMedicaid}
+              recommendedOverChip={recommendedOverChip}
               onToggle={() => toggle(meta.id)}
             />
           );
@@ -199,6 +206,7 @@ function Card({
   eligibility,
   claimed,
   overshadowedByMedicaid = false,
+  recommendedOverChip = false,
   onToggle,
 }: {
   meta: BenefitMeta;
@@ -209,6 +217,11 @@ function Card({
    *  CHIP would add $0 (Medicaid covers kids too). The card surfaces the
    *  redundancy and disables the claim affordance. */
   overshadowedByMedicaid?: boolean;
+  /** Medicaid-only: true when both Medicaid and CHIP are eligible, in
+   *  which case Medicaid is the strictly better choice (covers everyone,
+   *  zero out-of-pocket, broader benefits). Surfaces a small recommended
+   *  badge so the user doesn't accidentally pick CHIP-only. */
+  recommendedOverChip?: boolean;
   onToggle: () => void;
 }) {
   const eligible = eligibility.eligible;
@@ -290,6 +303,27 @@ function Card({
         </div>
         <EligibilityBadge eligible={eligible} claimed={claimed} phantomEligible={phantomEligible} />
       </div>
+
+      {recommendedOverChip && !claimed && (
+        <div
+          style={{
+            display: 'inline-block',
+            fontSize: rem(10),
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+            color: T.positive,
+            background: 'rgba(45, 80, 22, 0.1)',
+            border: `1px solid ${T.positive}`,
+            padding: '3px 8px',
+            borderRadius: 2,
+            fontWeight: 600,
+            marginBottom: 8,
+          }}
+          title="When both Medicaid and CHIP are available, Medicaid is the better choice — it covers the whole household (kids included) at $0 cost with broader benefits than CHIP. Claiming Medicaid will automatically uncheck CHIP."
+        >
+          ★ Better option than CHIP
+        </div>
+      )}
 
       <div
         style={{

--- a/src/components/Benefits.tsx
+++ b/src/components/Benefits.tsx
@@ -32,6 +32,10 @@ interface BenefitMeta {
   source: Source | readonly Source[];
   /** Optional state-specific citation, computed at render time. */
   stateSource?: (inputs: BenefitInputs) => Source;
+  /** Plain-language explanation of how this benefit's monthly dollar value
+   *  is derived. Surfaced as a hover tooltip on the value display so the
+   *  reader can see what's behind the number. */
+  valueDerivation: string;
 }
 
 const BENEFIT_META: readonly BenefitMeta[] = [
@@ -43,6 +47,8 @@ const BENEFIT_META: readonly BenefitMeta[] = [
     appliesTo: 'Reduces the grocery line.',
     source: SNAP_SOURCE,
     stateSource: (inputs) => snapStateSource(inputs.state),
+    valueDerivation:
+      "USDA formula: max benefit for your household size (FY2026 schedule) minus 30% of estimated net income. Net income = gross − 20% earned-income deduction − the standard deduction. Real SNAP also subtracts shelter and childcare deductions; we don't model those yet.",
   },
   {
     id: 'medicaid',
@@ -52,6 +58,8 @@ const BENEFIT_META: readonly BenefitMeta[] = [
     appliesTo: 'Zeros out the healthcare line.',
     source: [MEDICAID_SOURCE, MEDICAID_EXPANSION_SOURCE],
     stateSource: (inputs) => medicaidStateSource(inputs.state),
+    valueDerivation:
+      "Treats Medicaid as worth your full modeled monthly healthcare premium — sourced from KFF's Employer Health Benefits Survey (worker share of an employer-sponsored family or single plan). The model uses the same number for both 'value of public coverage' and 'post-cliff out-of-pocket cost,' so the cliff drop on Discretionary equals the cliff drop on Take-home + benefits. A more honest model would split these (Medicaid is genuinely better than typical employer coverage; ACA marketplace replacements typically cost more). On the roadmap.",
   },
   {
     id: 'chip',
@@ -61,6 +69,8 @@ const BENEFIT_META: readonly BenefitMeta[] = [
     appliesTo: "Reduces the kids' share of healthcare.",
     source: [CHIP_SOURCE, CHIP_STATE_THRESHOLDS_SOURCE],
     stateSource: (inputs) => chipStateSource(inputs.state),
+    valueDerivation:
+      "The kids' marginal share of the family premium: family premium minus an adult-only baseline (single-coverage premium × number of adults). Both premiums sourced from KFF's Employer Health Benefits Survey. Real CHIP often charges small premiums above ~150% FPL; we treat coverage as fully replacing the kids' share for simplicity.",
   },
 ];
 
@@ -276,17 +286,11 @@ function Card({
 
       {eligible && eligibility.monthlyBenefit > 0 ? (
         <>
-          <div
-            style={{
-              fontFamily: fonts.mono,
-              fontSize: rem(16),
-              marginBottom: 4,
-              color: claimed ? T.bg : T.positive,
-              fontWeight: 600,
-            }}
-          >
-            ~{fmt(eligibility.monthlyBenefit)}/mo
-          </div>
+          <ValueWithDerivation
+            value={`~${fmt(eligibility.monthlyBenefit)}/mo`}
+            derivation={meta.valueDerivation}
+            claimed={claimed}
+          />
           <div
             style={{
               fontSize: rem(11),
@@ -420,6 +424,87 @@ function EligibilityBadge({
  * or press Escape to dismiss. e.stopPropagation prevents the click from
  * bubbling to the card-level role=button handler.
  */
+/** Renders the benefit's monthly dollar value with a hover/focus popover
+ *  that explains how the number was derived (formula, source, simplifying
+ *  assumptions). The value itself stays the same prominent mono number;
+ *  the tooltip is opt-in for readers who want to know what's behind it. */
+function ValueWithDerivation({
+  value,
+  derivation,
+  claimed,
+}: {
+  value: string;
+  derivation: string;
+  claimed: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ position: 'relative', display: 'inline-block', marginBottom: 4 }}>
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        aria-describedby={open ? 'value-derivation' : undefined}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          padding: 0,
+          cursor: 'help',
+          fontFamily: fonts.mono,
+          fontSize: rem(16),
+          fontWeight: 600,
+          color: claimed ? T.bg : T.positive,
+          textDecoration: 'underline',
+          textDecorationStyle: 'dotted',
+          textUnderlineOffset: 4,
+        }}
+      >
+        {value}
+      </button>
+      {open && (
+        <div
+          id="value-derivation"
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 6px)',
+            left: 0,
+            zIndex: 5,
+            width: 300,
+            padding: '10px 12px',
+            background: T.surface,
+            border: `1px solid ${T.border}`,
+            borderRadius: 4,
+            boxShadow: '0 4px 12px rgba(27, 24, 21, 0.12)',
+            fontFamily: fonts.body,
+            fontSize: rem(12),
+            lineHeight: 1.5,
+            color: T.ink,
+            fontStyle: 'normal',
+            pointerEvents: 'none',
+          }}
+        >
+          <div
+            style={{
+              fontSize: rem(10),
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: T.inkMuted,
+              fontWeight: 600,
+              marginBottom: 4,
+            }}
+          >
+            How this is computed
+          </div>
+          {derivation}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function PhantomEligibilityNote({
   programName,
   claimed,

--- a/src/components/BudgetExplorer.tsx
+++ b/src/components/BudgetExplorer.tsx
@@ -107,8 +107,16 @@ export function BudgetExplorer() {
   const toggleBenefit = useCallback((id: string) => {
     setClaimedBenefits((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+        // Claiming Medicaid auto-drops CHIP — Medicaid covers the entire
+        // household including kids, so a simultaneous CHIP claim adds
+        // nothing and just creates a misleading "Claimed" badge on a card
+        // that contributes zero. Mirrors the budget code's priority logic.
+        if (id === 'medicaid') next.delete('chip');
+      }
       return next;
     });
   }, []);

--- a/src/components/BudgetExplorer.tsx
+++ b/src/components/BudgetExplorer.tsx
@@ -23,6 +23,21 @@ import { CityComparison } from './CityComparison';
 import { CliffCurve } from './CliffCurve';
 import { Benefits } from './Benefits';
 import { Notes } from './Notes';
+import { PageNav, type PageNavSection } from './PageNav';
+import { PitWarning } from './PitWarning';
+
+const PAGE_NAV_SECTIONS: readonly PageNavSection[] = [
+  { id: 'customize', label: 'Customize' },
+  { id: 'benefits', label: 'Benefits' },
+  { id: 'summary', label: 'Summary' },
+  { id: 'income-flow', label: 'Take-home' },
+  { id: 'tax-brackets', label: 'Tax brackets' },
+  { id: 'expenses', label: 'Expenses' },
+  { id: 'plan', label: 'Discretionary plan' },
+  { id: 'geography', label: 'Geography' },
+  { id: 'cliffs', label: 'Cliffs' },
+  { id: 'notes', label: 'Notes' },
+];
 
 // Live initial values for a fresh page load (no shared link, no localStorage).
 // A single parent at $40K HoH with two kids in Columbus — picked so the
@@ -199,44 +214,74 @@ export function BudgetExplorer() {
          radial-gradient(circle at 80% 100%, rgba(45, 80, 22, 0.03), transparent 50%)`,
       }}
     >
+      <PageNav sections={PAGE_NAV_SECTIONS} />
       <div style={{ maxWidth: 1240, margin: '0 auto' }}>
         <Masthead />
-        <CustomizePanel {...inputState} />
-        <Benefits result={result} claimed={claimedBenefits} toggle={toggleBenefit} />
-        <StatRow result={result} />
-        <StatusBanner result={result} />
-        <IncomeFlow result={result} />
-        <BracketWalkthrough
-          result={result}
-          incomeA={incomeA}
-          incomeB={effectiveIncomeB}
-          hasPartner={twoIncome}
-          filing={filing}
-        />
-        <ExpenseBreakdown result={result} />
-        <DiscretionaryPlan result={result} />
-        <ShareLink shareUrl={shareUrl} />
-        <CityComparison
-          result={result}
-          compareCity={compareCity}
-          setCompareCity={setCompareCity}
-          incomeA={incomeA}
-          incomeB={effectiveIncomeB}
-          hasPartner={twoIncome}
-          filing={filing}
-          kids={kids}
-          lifestyle={lifestyle}
-        />
-        <CliffCurve
-          city={city}
-          kids={kids}
-          filing={filing}
-          lifestyle={lifestyle}
-          hasPartner={twoIncome}
-          incomeA={incomeA}
-          incomeB={effectiveIncomeB}
-        />
-        <Notes filing={filing} stateTaxSource={result.stateData.taxSource} />
+        <section id="customize" style={{ scrollMarginTop: 24 }}>
+          <CustomizePanel {...inputState} />
+        </section>
+        <section id="benefits" style={{ scrollMarginTop: 24 }}>
+          <PitWarning
+            city={city}
+            kids={kids}
+            filing={filing}
+            lifestyle={lifestyle}
+            hasPartner={twoIncome}
+            incomeA={incomeA}
+            incomeB={effectiveIncomeB}
+          />
+          <Benefits result={result} claimed={claimedBenefits} toggle={toggleBenefit} />
+        </section>
+        <section id="summary" style={{ scrollMarginTop: 24 }}>
+          <StatRow result={result} />
+          <StatusBanner result={result} />
+        </section>
+        <section id="income-flow" style={{ scrollMarginTop: 24 }}>
+          <IncomeFlow result={result} />
+        </section>
+        <section id="tax-brackets" style={{ scrollMarginTop: 24 }}>
+          <BracketWalkthrough
+            result={result}
+            incomeA={incomeA}
+            incomeB={effectiveIncomeB}
+            hasPartner={twoIncome}
+            filing={filing}
+          />
+        </section>
+        <section id="expenses" style={{ scrollMarginTop: 24 }}>
+          <ExpenseBreakdown result={result} />
+        </section>
+        <section id="plan" style={{ scrollMarginTop: 24 }}>
+          <DiscretionaryPlan result={result} />
+          <ShareLink shareUrl={shareUrl} />
+        </section>
+        <section id="geography" style={{ scrollMarginTop: 24 }}>
+          <CityComparison
+            result={result}
+            compareCity={compareCity}
+            setCompareCity={setCompareCity}
+            incomeA={incomeA}
+            incomeB={effectiveIncomeB}
+            hasPartner={twoIncome}
+            filing={filing}
+            kids={kids}
+            lifestyle={lifestyle}
+          />
+        </section>
+        <section id="cliffs" style={{ scrollMarginTop: 24 }}>
+          <CliffCurve
+            city={city}
+            kids={kids}
+            filing={filing}
+            lifestyle={lifestyle}
+            hasPartner={twoIncome}
+            incomeA={incomeA}
+            incomeB={effectiveIncomeB}
+          />
+        </section>
+        <section id="notes" style={{ scrollMarginTop: 24 }}>
+          <Notes filing={filing} stateTaxSource={result.stateData.taxSource} />
+        </section>
       </div>
     </div>
   );

--- a/src/components/BudgetExplorer.tsx
+++ b/src/components/BudgetExplorer.tsx
@@ -20,6 +20,7 @@ import { BracketWalkthrough } from './BracketWalkthrough';
 import { ExpenseBreakdown } from './ExpenseBreakdown';
 import { DiscretionaryPlan } from './DiscretionaryPlan';
 import { CityComparison } from './CityComparison';
+import { CliffCurve } from './CliffCurve';
 import { Benefits } from './Benefits';
 import { Notes } from './Notes';
 
@@ -225,6 +226,15 @@ export function BudgetExplorer() {
           filing={filing}
           kids={kids}
           lifestyle={lifestyle}
+        />
+        <CliffCurve
+          city={city}
+          kids={kids}
+          filing={filing}
+          lifestyle={lifestyle}
+          hasPartner={twoIncome}
+          incomeA={incomeA}
+          incomeB={effectiveIncomeB}
         />
         <Notes filing={filing} stateTaxSource={result.stateData.taxSource} />
       </div>

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -7,6 +7,7 @@ import {
   Tooltip,
   ResponsiveContainer,
   ReferenceLine,
+  ReferenceArea,
   ReferenceDot,
   CartesianGrid,
 } from 'recharts';
@@ -244,6 +245,33 @@ export function CliffCurve({
     null,
   );
 
+  // Pit zones: contiguous income ranges where the household ends up with
+  // less of the active metric than they would at some lower income. Walks
+  // the curve left→right tracking the running max; any point below that
+  // running max is "in a pit." Coalesces consecutive in-pit points into
+  // single shaded ranges so we render one ReferenceArea per zone.
+  const pitZones = useMemo(() => {
+    const zones: { x1: number; x2: number }[] = [];
+    let runningMax = -Infinity;
+    let currentZoneStart: number | null = null;
+    for (let i = 0; i < points.length; i++) {
+      const v = points[i][metricMeta.key] as number;
+      if (v < runningMax) {
+        if (currentZoneStart === null) currentZoneStart = points[i].gross;
+      } else {
+        if (currentZoneStart !== null) {
+          zones.push({ x1: currentZoneStart, x2: points[i].gross });
+          currentZoneStart = null;
+        }
+        runningMax = v;
+      }
+    }
+    if (currentZoneStart !== null) {
+      zones.push({ x1: currentZoneStart, x2: points[points.length - 1].gross });
+    }
+    return zones;
+  }, [points, metricMeta]);
+
   return (
     <div style={{ marginBottom: 48 }}>
       <SectionTitle kicker="The shape of the safety net">
@@ -319,6 +347,18 @@ export function CliffCurve({
                 <CliffTooltip {...props} cliffs={cliffs} metric={metricMeta} />
               )}
             />
+            {pitZones.map((z, i) => (
+              <ReferenceArea
+                key={`pit-${i}`}
+                x1={z.x1}
+                x2={z.x2}
+                fill={T.warning}
+                fillOpacity={0.1}
+                stroke={T.warning}
+                strokeOpacity={0.25}
+                strokeDasharray="2 3"
+              />
+            ))}
             <ReferenceLine y={0} stroke={T.inkMuted} strokeWidth={1} />
             {cliffs.map((c) => (
               <ReferenceLine
@@ -391,6 +431,23 @@ export function CliffCurve({
             />
             Your current income ({fmt(currentGross)})
           </span>
+          {pitZones.length > 0 && (
+            <span>
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 14,
+                  height: 10,
+                  background: T.warning,
+                  opacity: 0.25,
+                  border: `1px dashed ${T.warning}`,
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                }}
+              />
+              Worse off than at some lower income
+            </span>
+          )}
           {cliffs.map((c) => (
             <span key={c.id + c.gross}>
               <span

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -48,7 +48,7 @@ const METRICS: Record<
     key: 'discretionary',
     unitNoun: 'discretionary',
     description:
-      "What's actually left over each year after taxes and modeled household expenses (rent, groceries, healthcare, childcare, etc.). The most editorial measure — answers \"how much can the household actually spend after the bills are paid?\"",
+      'What\'s actually left over each year after taxes and modeled household expenses (rent, groceries, healthcare, childcare, etc.). The most editorial measure — answers "how much can the household actually spend after the bills are paid?"',
   },
   takeHome: {
     label: 'Take-home',
@@ -56,7 +56,7 @@ const METRICS: Record<
     key: 'takeHome',
     unitNoun: 'take-home',
     description:
-      "Gross income minus federal, state, local, and FICA taxes. Ignores expenses and benefits entirely. Benefit cliffs are invisible on this line — only tax-bracket transitions and EITC/CTC phaseouts bend the curve. Useful for separating what the tax code does from what the safety net does.",
+      'Gross income minus federal, state, local, and FICA taxes. Ignores expenses and benefits entirely. Benefit cliffs are invisible on this line — only tax-bracket transitions and EITC/CTC phaseouts bend the curve. Useful for separating what the tax code does from what the safety net does.',
   },
   takeHomePlusBenefits: {
     label: 'Take-home + benefits',
@@ -64,7 +64,7 @@ const METRICS: Record<
     key: 'takeHomePlusBenefits',
     unitNoun: 'total resources',
     description:
-      "Take-home pay plus the dollar value of every safety-net benefit the household qualifies for (Medicaid, CHIP, SNAP). The total cash + in-kind resources reaching the household. Cliffs here are the same size as on Discretionary — both just drop by the value of the lost program — but the baseline runs higher because benefits stack onto take-home instead of getting netted out against expenses.",
+      'Take-home pay plus the dollar value of every safety-net benefit the household qualifies for (Medicaid, CHIP, SNAP). The total cash + in-kind resources reaching the household. Cliffs here are the same size as on Discretionary — both just drop by the value of the lost program — but the baseline runs higher because benefits stack onto take-home instead of getting netted out against expenses.',
   },
 };
 
@@ -228,9 +228,7 @@ export function CliffCurve({
       const halfWidth = labelHalfWidthDollars(c.shortLabel);
       let row = 0;
       while (
-        placed.some(
-          (p) => p.row === row && Math.abs(p.gross - c.gross) < halfWidth + p.halfWidth,
-        )
+        placed.some((p) => p.row === row && Math.abs(p.gross - c.gross) < halfWidth + p.halfWidth)
       ) {
         row += 1;
       }
@@ -318,132 +316,130 @@ export function CliffCurve({
             }}
           >
             Same household in {cityData.name}, {cityData.state} — sweeping gross income from $0 to{' '}
-            {fmt(maxGross)}. The curve is smooth where the tax code phases things in gradually.
-            The vertical drops are <em>cliffs</em>: a single dollar of additional income
-            disqualifies the household from a program entirely.
+            {fmt(maxGross)}. The curve is smooth where the tax code phases things in gradually. The
+            vertical drops are <em>cliffs</em>: a single dollar of additional income disqualifies
+            the household from a program entirely.
           </div>
           <MetricToggle metric={metric} onChange={setMetric} />
         </div>
 
         <div ref={chartWrapperRef}>
-        <ResponsiveContainer width="100%" height={340}>
-          <LineChart
-            data={points}
-            margin={{
-              top: 20 + Math.max(0, ...cliffs.map((c) => c.labelRow)) * 13,
-              right: 24,
-              left: 8,
-              bottom: 16,
-            }}
-          >
-            <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
-            <XAxis
-              dataKey="gross"
-              type="number"
-              domain={[0, maxGross]}
-              tickFormatter={(v) => `$${Math.round(v / 1000)}K`}
-              stroke={T.inkMuted}
-              tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
-              label={{
-                value: 'Gross household income',
-                position: 'insideBottom',
-                offset: -8,
-                style: {
-                  fontSize: 11,
-                  fill: T.inkMuted,
-                  fontFamily: fonts.body,
-                  letterSpacing: '0.1em',
-                },
+          <ResponsiveContainer width="100%" height={340}>
+            <LineChart
+              data={points}
+              margin={{
+                top: 20 + Math.max(0, ...cliffs.map((c) => c.labelRow)) * 13,
+                right: 24,
+                left: 8,
+                bottom: 16,
               }}
-            />
-            <YAxis
-              tickFormatter={(v) => (v === 0 ? '$0' : `$${Math.round(v / 1000)}K`)}
-              stroke={T.inkMuted}
-              tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
-              width={56}
-            />
-            <Tooltip
-              content={(props) => (
-                <CliffTooltip {...props} cliffs={cliffs} metric={metricMeta} />
-              )}
-            />
-            {pitZones.map((z, i) => (
-              <ReferenceArea
-                key={`pit-${i}`}
-                x1={z.x1}
-                x2={z.x2}
-                fill={T.warning}
-                fillOpacity={0.12}
-                stroke={T.warning}
-                strokeOpacity={0.3}
-                strokeDasharray="2 3"
-              />
-            ))}
-            <ReferenceLine y={0} stroke={T.inkMuted} strokeWidth={1} />
-            {cliffs.map((c) => (
-              <ReferenceLine
-                key={c.id + c.gross}
-                x={c.gross}
-                stroke={c.color}
-                strokeDasharray="3 3"
-                label={(props: { viewBox?: { x?: number; y?: number } }) => {
-                  const x = props.viewBox?.x ?? 0;
-                  const y = props.viewBox?.y ?? 0;
-                  // Label sits in the chart's top margin; for bumped rows
-                  // it's even higher up. The ReferenceLine itself only
-                  // draws inside the plot area, so when row > 0 we add a
-                  // matching dashed connector from the chart top up to
-                  // just below the label so the eye can follow line→label.
-                  const labelY = y - 6 - c.labelRow * 13;
-                  return (
-                    <g>
-                      {c.labelRow > 0 && (
-                        <line
-                          x1={x}
-                          x2={x}
-                          y1={y}
-                          y2={labelY + 2}
-                          stroke={c.color}
-                          strokeDasharray="3 3"
-                          strokeWidth={1}
-                        />
-                      )}
-                      <text
-                        x={x}
-                        y={labelY}
-                        fill={c.color}
-                        fontSize={10}
-                        fontFamily={fonts.body}
-                        textAnchor="middle"
-                      >
-                        {c.shortLabel}
-                      </text>
-                    </g>
-                  );
+            >
+              <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+              <XAxis
+                dataKey="gross"
+                type="number"
+                domain={[0, maxGross]}
+                tickFormatter={(v) => `$${Math.round(v / 1000)}K`}
+                stroke={T.inkMuted}
+                tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
+                label={{
+                  value: 'Gross household income',
+                  position: 'insideBottom',
+                  offset: -8,
+                  style: {
+                    fontSize: 11,
+                    fill: T.inkMuted,
+                    fontFamily: fonts.body,
+                    letterSpacing: '0.1em',
+                  },
                 }}
               />
-            ))}
-            <Line
-              type="monotone"
-              dataKey={metricMeta.key}
-              stroke={T.ink}
-              strokeWidth={2}
-              dot={false}
-              isAnimationActive={false}
-            />
-            {userPoint && (
-              <ReferenceDot
-                x={userPoint.gross}
-                y={userPoint[metricMeta.key] as number}
-                r={5}
-                fill={T.positive}
-                stroke={T.bg}
-                strokeWidth={2}
-                ifOverflow="visible"
+              <YAxis
+                tickFormatter={(v) => (v === 0 ? '$0' : `$${Math.round(v / 1000)}K`)}
+                stroke={T.inkMuted}
+                tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
+                width={56}
               />
-            )}
-          </LineChart>
-        </ResponsiveContainer>
+              <Tooltip
+                content={(props) => <CliffTooltip {...props} cliffs={cliffs} metric={metricMeta} />}
+              />
+              {pitZones.map((z, i) => (
+                <ReferenceArea
+                  key={`pit-${i}`}
+                  x1={z.x1}
+                  x2={z.x2}
+                  fill={T.warning}
+                  fillOpacity={0.12}
+                  stroke={T.warning}
+                  strokeOpacity={0.3}
+                  strokeDasharray="2 3"
+                />
+              ))}
+              <ReferenceLine y={0} stroke={T.inkMuted} strokeWidth={1} />
+              {cliffs.map((c) => (
+                <ReferenceLine
+                  key={c.id + c.gross}
+                  x={c.gross}
+                  stroke={c.color}
+                  strokeDasharray="3 3"
+                  label={(props: { viewBox?: { x?: number; y?: number } }) => {
+                    const x = props.viewBox?.x ?? 0;
+                    const y = props.viewBox?.y ?? 0;
+                    // Label sits in the chart's top margin; for bumped rows
+                    // it's even higher up. The ReferenceLine itself only
+                    // draws inside the plot area, so when row > 0 we add a
+                    // matching dashed connector from the chart top up to
+                    // just below the label so the eye can follow line→label.
+                    const labelY = y - 6 - c.labelRow * 13;
+                    return (
+                      <g>
+                        {c.labelRow > 0 && (
+                          <line
+                            x1={x}
+                            x2={x}
+                            y1={y}
+                            y2={labelY + 2}
+                            stroke={c.color}
+                            strokeDasharray="3 3"
+                            strokeWidth={1}
+                          />
+                        )}
+                        <text
+                          x={x}
+                          y={labelY}
+                          fill={c.color}
+                          fontSize={10}
+                          fontFamily={fonts.body}
+                          textAnchor="middle"
+                        >
+                          {c.shortLabel}
+                        </text>
+                      </g>
+                    );
+                  }}
+                />
+              ))}
+              <Line
+                type="monotone"
+                dataKey={metricMeta.key}
+                stroke={T.ink}
+                strokeWidth={2}
+                dot={false}
+                isAnimationActive={false}
+              />
+              {userPoint && (
+                <ReferenceDot
+                  x={userPoint.gross}
+                  y={userPoint[metricMeta.key] as number}
+                  r={5}
+                  fill={T.positive}
+                  stroke={T.bg}
+                  strokeWidth={2}
+                  ifOverflow="visible"
+                />
+              )}
+            </LineChart>
+          </ResponsiveContainer>
         </div>
 
         <div
@@ -532,10 +528,8 @@ export function CliffCurve({
                   At <strong style={{ color: T.ink, fontStyle: 'normal' }}>{fmt(c.gross)}</strong>,
                   losing <strong style={{ color: T.ink, fontStyle: 'normal' }}>{c.label}</strong>{' '}
                   costs roughly{' '}
-                  <strong style={{ color: T.ink, fontStyle: 'normal' }}>
-                    {fmt(c.drop)}/yr
-                  </strong>{' '}
-                  in {metricMeta.unitNoun}.{' '}
+                  <strong style={{ color: T.ink, fontStyle: 'normal' }}>{fmt(c.drop)}/yr</strong> in{' '}
+                  {metricMeta.unitNoun}.{' '}
                   {c.recoveryGross !== null ? (
                     <>
                       The household isn't back to even until they earn{' '}
@@ -546,8 +540,8 @@ export function CliffCurve({
                     </>
                   ) : (
                     <>
-                      The curve doesn't recover within the swept range — the household stays
-                      poorer than they were at {fmt(c.gross)} all the way to {fmt(maxGross)}.
+                      The curve doesn't recover within the swept range — the household stays poorer
+                      than they were at {fmt(c.gross)} all the way to {fmt(maxGross)}.
                     </>
                   )}
                 </li>
@@ -584,13 +578,7 @@ export function CliffCurve({
   );
 }
 
-function MetricToggle({
-  metric,
-  onChange,
-}: {
-  metric: MetricId;
-  onChange: (m: MetricId) => void;
-}) {
+function MetricToggle({ metric, onChange }: { metric: MetricId; onChange: (m: MetricId) => void }) {
   // Track which button is currently hovered/focused so the popover below
   // shows that button's description; null = no popover.
   const [previewing, setPreviewing] = useState<MetricId | null>(null);

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import {
   LineChart,
   Line,
@@ -25,6 +25,37 @@ import {
 } from '@/data/benefits';
 import { getCityData } from '@/data/cities';
 import { SectionTitle } from './ui';
+
+type MetricId = 'discretionary' | 'takeHome' | 'takeHomePlusBenefits';
+
+interface SweepPoint {
+  gross: number;
+  discretionary: number;
+  takeHome: number;
+  takeHomePlusBenefits: number;
+  benefits: number;
+}
+
+const METRICS: Record<MetricId, { label: string; longLabel: string; key: keyof SweepPoint; unitNoun: string }> = {
+  discretionary: {
+    label: 'Discretionary',
+    longLabel: 'Annual discretionary income',
+    key: 'discretionary',
+    unitNoun: 'discretionary',
+  },
+  takeHome: {
+    label: 'Take-home',
+    longLabel: 'Annual take-home pay (net of taxes)',
+    key: 'takeHome',
+    unitNoun: 'take-home',
+  },
+  takeHomePlusBenefits: {
+    label: 'Take-home + benefits',
+    longLabel: 'Annual take-home pay + benefit value',
+    key: 'takeHomePlusBenefits',
+    unitNoun: 'total resources',
+  },
+};
 
 /**
  * Income-sweep view that exposes the discontinuities baked into the safety
@@ -60,6 +91,15 @@ export function CliffCurve({
   const householdSize = (hasPartner ? 2 : 1) + kids;
   const allBenefits = useMemo<ReadonlySet<string>>(() => new Set(BENEFIT_IDS), []);
 
+  // Which financial measure to plot on the Y axis. Discretionary is the most
+  // editorial (what's actually left over after expenses), but it muddies
+  // the cliff visually because some lost benefits — Medicaid in particular
+  // — also raise the household's healthcare expense, partially offsetting
+  // the take-home drop. Take-home and total-resources views isolate the
+  // pure cash impact.
+  const [metric, setMetric] = useState<MetricId>('discretionary');
+  const metricMeta = METRICS[metric];
+
   const currentGross = incomeA + incomeB;
   // Sweep up to $200K or 1.5× current income, whichever is higher, so the
   // user's dot is always visible with cliff territory still on screen.
@@ -68,7 +108,7 @@ export function CliffCurve({
   const stepSize = Math.max(500, Math.round(maxGross / stepCount / 500) * 500);
 
   const points = useMemo(() => {
-    const out: { gross: number; discretionary: number; benefits: number }[] = [];
+    const out: SweepPoint[] = [];
     for (let g = 0; g <= maxGross; g += stepSize) {
       const sweepIncomeA = Math.max(0, g - incomeB);
       const r = computeBudget({
@@ -81,10 +121,13 @@ export function CliffCurve({
         lifestyle,
         claimedBenefits: allBenefits,
       });
+      const annualBenefits = r.totalBenefits * 12;
       out.push({
         gross: g,
         discretionary: Math.round(r.annualDiscretionary),
-        benefits: Math.round(r.totalBenefits * 12),
+        takeHome: Math.round(r.netIncome),
+        takeHomePlusBenefits: Math.round(r.netIncome + annualBenefits),
+        benefits: Math.round(annualBenefits),
       });
     }
     return out;
@@ -172,6 +215,8 @@ export function CliffCurve({
   }, [points, currentGross, maxGross]);
 
   // Quantify each cliff's drop magnitude — useful for the editorial caption.
+  // Uses whichever metric the user has selected so the caption matches the
+  // chart line.
   const cliffDrops = useMemo(() => {
     return cliffs.map((c) => {
       let before = points[0];
@@ -180,10 +225,10 @@ export function CliffCurve({
         else break;
       }
       const after = points.find((p) => p.gross > c.gross) ?? points[points.length - 1];
-      const drop = before.discretionary - after.discretionary;
+      const drop = (before[metricMeta.key] as number) - (after[metricMeta.key] as number);
       return { ...c, drop };
     });
-  }, [cliffs, points]);
+  }, [cliffs, points, metricMeta]);
 
   const biggestCliff = cliffDrops.reduce<(typeof cliffDrops)[number] | null>(
     (max, c) => (c.drop > (max?.drop ?? 0) ? c : max),
@@ -199,17 +244,29 @@ export function CliffCurve({
       <div style={{ background: T.surface, border: `1px solid ${T.border}`, padding: '20px 16px' }}>
         <div
           style={{
-            fontFamily: fonts.body,
-            fontSize: rem(13),
-            color: T.inkSoft,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-end',
+            gap: 16,
+            flexWrap: 'wrap',
             marginBottom: 12,
-            lineHeight: 1.5,
           }}
         >
-          Same household in {cityData.name}, {cityData.state} — sweeping gross income from $0 to{' '}
-          {fmt(maxGross)}. The curve is smooth where the tax code phases things in gradually.
-          The vertical drops are <em>cliffs</em>: a single dollar of additional income disqualifies
-          the household from a program entirely.
+          <div
+            style={{
+              fontFamily: fonts.body,
+              fontSize: rem(13),
+              color: T.inkSoft,
+              lineHeight: 1.5,
+              flex: '1 1 280px',
+            }}
+          >
+            Same household in {cityData.name}, {cityData.state} — sweeping gross income from $0 to{' '}
+            {fmt(maxGross)}. The curve is smooth where the tax code phases things in gradually.
+            The vertical drops are <em>cliffs</em>: a single dollar of additional income
+            disqualifies the household from a program entirely.
+          </div>
+          <MetricToggle metric={metric} onChange={setMetric} />
         </div>
 
         <ResponsiveContainer width="100%" height={340}>
@@ -248,7 +305,11 @@ export function CliffCurve({
               tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
               width={56}
             />
-            <Tooltip content={(props) => <CliffTooltip {...props} cliffs={cliffs} />} />
+            <Tooltip
+              content={(props) => (
+                <CliffTooltip {...props} cliffs={cliffs} metric={metricMeta} />
+              )}
+            />
             <ReferenceLine y={0} stroke={T.inkMuted} strokeWidth={1} />
             {cliffs.map((c) => (
               <ReferenceLine
@@ -276,7 +337,7 @@ export function CliffCurve({
             ))}
             <Line
               type="monotone"
-              dataKey="discretionary"
+              dataKey={metricMeta.key}
               stroke={T.ink}
               strokeWidth={2}
               dot={false}
@@ -285,7 +346,7 @@ export function CliffCurve({
             {userPoint && (
               <ReferenceDot
                 x={userPoint.gross}
-                y={userPoint.discretionary}
+                y={userPoint[metricMeta.key] as number}
                 r={5}
                 fill={T.positive}
                 stroke={T.bg}
@@ -350,12 +411,51 @@ export function CliffCurve({
             }}
           >
             At {fmt(biggestCliff.gross)} of gross income, earning one more dollar costs this
-            household roughly {fmt(biggestCliff.drop)} a year — the value of the {biggestCliff.label}{' '}
-            coverage they no longer qualify for. A raise of less than that leaves them poorer than
-            before.
+            household roughly {fmt(biggestCliff.drop)} a year in {metricMeta.unitNoun} — the value
+            of the {biggestCliff.label} coverage they no longer qualify for. A raise of less than
+            that leaves them poorer than before.
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function MetricToggle({
+  metric,
+  onChange,
+}: {
+  metric: MetricId;
+  onChange: (m: MetricId) => void;
+}) {
+  return (
+    <div role="group" aria-label="Metric to plot" style={{ display: 'inline-flex', gap: 0 }}>
+      {(Object.keys(METRICS) as MetricId[]).map((id, i) => {
+        const isActive = metric === id;
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onChange(id)}
+            aria-pressed={isActive}
+            style={{
+              fontFamily: fonts.body,
+              fontSize: rem(11),
+              letterSpacing: '0.04em',
+              padding: '6px 10px',
+              border: `1px solid ${isActive ? T.ink : T.border}`,
+              borderLeftWidth: i === 0 ? 1 : 0,
+              background: isActive ? T.ink : T.bg,
+              color: isActive ? T.bg : T.inkSoft,
+              cursor: 'pointer',
+              fontWeight: isActive ? 600 : 400,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {METRICS[id].label}
+          </button>
+        );
+      })}
     </div>
   );
 }
@@ -365,11 +465,16 @@ function CliffTooltip({
   payload,
   label,
   cliffs,
-}: TooltipContentProps & { cliffs: { id: string; label: string; gross: number }[] }) {
+  metric,
+}: TooltipContentProps & {
+  cliffs: { id: string; label: string; gross: number }[];
+  metric: (typeof METRICS)[MetricId];
+}) {
   if (!active || !payload || !payload.length) return null;
   const gross = typeof label === 'number' ? label : Number(label);
-  const point = payload[0]?.payload as { discretionary: number; benefits: number } | undefined;
+  const point = payload[0]?.payload as SweepPoint | undefined;
   if (!point) return null;
+  const value = point[metric.key] as number;
   const activePrograms = cliffs.filter((c) => gross <= c.gross);
   return (
     <div
@@ -382,10 +487,10 @@ function CliffTooltip({
       }}
     >
       <div style={{ color: T.inkMuted, marginBottom: 2 }}>Gross {fmt(gross)}/yr</div>
-      <div style={{ fontFamily: fonts.mono, color: point.discretionary >= 0 ? T.positive : T.accent }}>
-        {fmt(point.discretionary)}/yr discretionary
+      <div style={{ fontFamily: fonts.mono, color: value >= 0 ? T.positive : T.accent }}>
+        {fmt(value)}/yr {metric.unitNoun}
       </div>
-      {point.benefits > 0 && (
+      {point.benefits > 0 && metric.key !== 'takeHomePlusBenefits' && (
         <div style={{ fontFamily: fonts.mono, color: T.inkSoft, marginTop: 2 }}>
           + {fmt(point.benefits)}/yr in benefits
         </div>

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -554,6 +554,31 @@ export function CliffCurve({
               ))}
           </ul>
         )}
+
+        {cliffDrops.some((c) => c.id === 'medicaid' && c.drop > 0) &&
+          cliffDrops.some((c) => c.id === 'chip' && c.drop > 0) && (
+            <div
+              style={{
+                marginTop: 14,
+                padding: '10px 14px',
+                background: T.bgAlt,
+                border: `1px dashed ${T.border}`,
+                borderRadius: 4,
+                fontFamily: fonts.body,
+                fontSize: rem(12),
+                color: T.inkSoft,
+                lineHeight: 1.6,
+              }}
+            >
+              <strong style={{ color: T.ink, fontWeight: 600 }}>
+                Note the Medicaid → CHIP handoff.
+              </strong>{' '}
+              At the Medicaid cutoff, the kids transition to CHIP automatically — so the visible
+              Medicaid cliff only reflects the <em>adults'</em> coverage loss, not the full family
+              premium. The kids' coverage cliff comes later, at the CHIP cutoff. Together the two
+              drops add up to the full family healthcare cost.
+            </div>
+          )}
       </div>
     </div>
   );

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -149,10 +149,12 @@ export function CliffCurve({
   // for this household size and state.
   const cliffs = useMemo(() => {
     const fplBase = fpl(householdSize);
-    const list: { id: string; label: string; gross: number; color: string }[] = [];
+    const list: { id: string; shortLabel: string; label: string; gross: number; color: string }[] =
+      [];
 
     list.push({
       id: 'snap',
+      shortLabel: 'SNAP',
       label: 'SNAP',
       gross: Math.round(fplBase * snapIncomeLimitFpl(cityData.state)),
       color: T.warning,
@@ -162,6 +164,7 @@ export function CliffCurve({
     if (policy.expanded) {
       list.push({
         id: 'medicaid',
+        shortLabel: 'Medicaid',
         label: 'Medicaid (138% FPL)',
         gross: Math.round(fplBase * MEDICAID_EXPANSION_LIMIT_FPL),
         color: T.accent,
@@ -170,6 +173,7 @@ export function CliffCurve({
       const pct = Math.round(policy.nonExpansionParentLimit * 100);
       list.push({
         id: 'medicaid',
+        shortLabel: 'Medicaid parents',
         label: `Medicaid parents (${pct}% FPL)`,
         gross: Math.round(fplBase * policy.nonExpansionParentLimit),
         color: T.accent,
@@ -180,6 +184,7 @@ export function CliffCurve({
       const chipLimit = STATE_CHIP_LIMIT_FPL[cityData.state];
       list.push({
         id: 'chip',
+        shortLabel: 'CHIP',
         label: `CHIP (${Math.round(chipLimit * 100)}% FPL)`,
         gross: Math.round(fplBase * chipLimit),
         color: T.aiAccent,
@@ -386,7 +391,7 @@ export function CliffCurve({
                         fontFamily={fonts.body}
                         textAnchor="middle"
                       >
-                        {c.label}
+                        {c.shortLabel}
                       </text>
                     </g>
                   );

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -224,9 +224,15 @@ export function CliffCurve({
     // the left and the right margin eats ~24px; subtract those before
     // converting. This collapses to per-label clearance instead of a
     // hand-tuned fraction of maxGross.
-    const plotWidthPx = Math.max(50, chartWidthPx - 56 - 24);
+    // Plot area: wrapper minus YAxis (56), right margin (24), left margin (8).
+    const plotWidthPx = Math.max(50, chartWidthPx - 56 - 24 - 8);
     const pxPerDollar = plotWidthPx / Math.max(1, maxGross);
-    const labelHalfWidthDollars = (label: string) => (label.length * 5.5 + 8) / 2 / pxPerDollar;
+    // Empirical: 10px IBM Plex Sans averages ~5px per char, with no extra
+    // padding before two labels visually touch. Earlier estimate of
+    // 5.5px + 8px padding was over-generous and bumped labels that
+    // actually had room — particularly short ones like "SNAP" sitting
+    // between two longer neighbours.
+    const labelHalfWidthDollars = (label: string) => (label.length * 5) / 2 / pxPerDollar;
     const placed: { gross: number; halfWidth: number; row: number }[] = [];
     return visible.map((c) => {
       const halfWidth = labelHalfWidthDollars(c.shortLabel);

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   LineChart,
   Line,
@@ -100,6 +100,23 @@ export function CliffCurve({
 }) {
   const cityData = getCityData(city);
   const householdSize = (hasPartner ? 2 : 1) + kids;
+
+  // Measure the chart wrapper so the label-stagger math can convert
+  // pixel-width estimates of each label into gross-dollar minSpacing.
+  // Without this we'd be picking a hand-tuned fraction of maxGross that
+  // either over- or under-bumps depending on label text and sweep range.
+  const chartWrapperRef = useRef<HTMLDivElement | null>(null);
+  const [chartWidthPx, setChartWidthPx] = useState(640);
+  useEffect(() => {
+    const el = chartWrapperRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (typeof w === 'number' && w > 0) setChartWidthPx(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
   const allBenefits = useMemo<ReadonlySet<string>>(() => new Set(BENEFIT_IDS), []);
 
   // Which financial measure to plot on the Y axis. Discretionary is the most
@@ -199,21 +216,32 @@ export function CliffCurve({
       .filter((c) => c.gross > 0 && c.gross <= maxGross)
       .sort((a, b) => a.gross - b.gross);
     // Stagger: each label takes the *lowest* row where it doesn't
-    // horizontally overlap any label already placed at that row. So three
-    // close-together labels go (0, 1, 2), but if the third one is actually
-    // far enough from the first, it drops back to row 0 instead of
-    // climbing forever. Two labels far apart both stay at row 0.
-    const minSpacing = maxGross * 0.1;
-    const placed: { gross: number; row: number }[] = [];
+    // horizontally overlap any label already placed at that row. We
+    // compute each label's required horizontal clearance in actual gross
+    // dollars from (a) its rendered pixel width estimate (chars × ~5.5px
+    // at 10px font) and (b) the chart's measured pixel width. The plot
+    // area is narrower than the wrapper because the YAxis eats ~56px on
+    // the left and the right margin eats ~24px; subtract those before
+    // converting. This collapses to per-label clearance instead of a
+    // hand-tuned fraction of maxGross.
+    const plotWidthPx = Math.max(50, chartWidthPx - 56 - 24);
+    const pxPerDollar = plotWidthPx / Math.max(1, maxGross);
+    const labelHalfWidthDollars = (label: string) => (label.length * 5.5 + 8) / 2 / pxPerDollar;
+    const placed: { gross: number; halfWidth: number; row: number }[] = [];
     return visible.map((c) => {
+      const halfWidth = labelHalfWidthDollars(c.shortLabel);
       let row = 0;
-      while (placed.some((p) => p.row === row && Math.abs(p.gross - c.gross) < minSpacing)) {
+      while (
+        placed.some(
+          (p) => p.row === row && Math.abs(p.gross - c.gross) < halfWidth + p.halfWidth,
+        )
+      ) {
         row += 1;
       }
-      placed.push({ gross: c.gross, row });
+      placed.push({ gross: c.gross, halfWidth, row });
       return { ...c, labelRow: row };
     });
-  }, [householdSize, cityData.state, kids, maxGross]);
+  }, [householdSize, cityData.state, kids, maxGross, chartWidthPx]);
 
   const userPoint = useMemo(() => {
     if (currentGross < 0 || currentGross > maxGross) return null;
@@ -301,6 +329,7 @@ export function CliffCurve({
           <MetricToggle metric={metric} onChange={setMetric} />
         </div>
 
+        <div ref={chartWrapperRef}>
         <ResponsiveContainer width="100%" height={340}>
           <LineChart
             data={points}
@@ -419,6 +448,7 @@ export function CliffCurve({
             )}
           </LineChart>
         </ResponsiveContainer>
+        </div>
 
         <div
           style={{
@@ -540,13 +570,12 @@ function MetricToggle({
   metric: MetricId;
   onChange: (m: MetricId) => void;
 }) {
-  // Track which button is currently hovered/focused so the description
-  // line below previews that one — falls back to the active metric.
+  // Track which button is currently hovered/focused so the popover below
+  // shows that button's description; null = no popover.
   const [previewing, setPreviewing] = useState<MetricId | null>(null);
-  const shown = previewing ?? metric;
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
+    <div style={{ position: 'relative', display: 'inline-block' }}>
       <div role="group" aria-label="Metric to plot" style={{ display: 'inline-flex', gap: 0 }}>
         {(Object.keys(METRICS) as MetricId[]).map((id, i) => {
           const isActive = metric === id;
@@ -560,8 +589,7 @@ function MetricToggle({
               onFocus={() => setPreviewing(id)}
               onBlur={() => setPreviewing(null)}
               aria-pressed={isActive}
-              aria-describedby={`metric-${id}-desc`}
-              title={METRICS[id].description}
+              aria-describedby={previewing === id ? 'metric-popover' : undefined}
               style={{
                 fontFamily: fonts.body,
                 fontSize: rem(11),
@@ -581,22 +609,32 @@ function MetricToggle({
           );
         })}
       </div>
-      <div
-        id={`metric-${shown}-desc`}
-        role="status"
-        aria-live="polite"
-        style={{
-          fontFamily: fonts.body,
-          fontSize: rem(11),
-          color: T.inkMuted,
-          maxWidth: 360,
-          textAlign: 'right',
-          lineHeight: 1.5,
-          fontStyle: 'italic',
-        }}
-      >
-        {METRICS[shown].description}
-      </div>
+      {previewing && (
+        <div
+          id="metric-popover"
+          role="tooltip"
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            marginTop: 6,
+            maxWidth: 320,
+            padding: '8px 12px',
+            background: T.surface,
+            border: `1px solid ${T.border}`,
+            boxShadow: '0 6px 16px rgba(27, 24, 21, 0.12)',
+            fontFamily: fonts.body,
+            fontSize: rem(11),
+            color: T.inkSoft,
+            lineHeight: 1.5,
+            fontStyle: 'italic',
+            zIndex: 10,
+            pointerEvents: 'none',
+          }}
+        >
+          {METRICS[previewing].description}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -255,10 +255,17 @@ export function CliffCurve({
   // Pit zones: contiguous income ranges where the household ends up with
   // less of the active metric than they would at some lower income. Walks
   // the curve left→right tracking the running max; any point below that
-  // running max is "in a pit." Coalesces consecutive in-pit points into
-  // single shaded ranges so we render one ReferenceArea per zone.
+  // running max is "in a pit." Each zone is attributed to the cliff that
+  // caused it — the highest-gross cliff at or below the zone start —
+  // so the shading color can match that program's accent.
   const pitZones = useMemo(() => {
-    const zones: { x1: number; x2: number }[] = [];
+    const sortedCliffs = [...cliffs].sort((a, b) => b.gross - a.gross); // desc
+    const findCauseColor = (zoneStart: number): string => {
+      const cause = sortedCliffs.find((c) => c.gross < zoneStart);
+      return cause?.color ?? T.warning;
+    };
+
+    const zones: { x1: number; x2: number; color: string }[] = [];
     let runningMax = -Infinity;
     let currentZoneStart: number | null = null;
     for (let i = 0; i < points.length; i++) {
@@ -267,17 +274,25 @@ export function CliffCurve({
         if (currentZoneStart === null) currentZoneStart = points[i].gross;
       } else {
         if (currentZoneStart !== null) {
-          zones.push({ x1: currentZoneStart, x2: points[i].gross });
+          zones.push({
+            x1: currentZoneStart,
+            x2: points[i].gross,
+            color: findCauseColor(currentZoneStart),
+          });
           currentZoneStart = null;
         }
         runningMax = v;
       }
     }
     if (currentZoneStart !== null) {
-      zones.push({ x1: currentZoneStart, x2: points[points.length - 1].gross });
+      zones.push({
+        x1: currentZoneStart,
+        x2: points[points.length - 1].gross,
+        color: findCauseColor(currentZoneStart),
+      });
     }
     return zones;
-  }, [points, metricMeta]);
+  }, [points, metricMeta, cliffs]);
 
   return (
     <div style={{ marginBottom: 48 }}>
@@ -359,10 +374,10 @@ export function CliffCurve({
                 key={`pit-${i}`}
                 x1={z.x1}
                 x2={z.x2}
-                fill={T.warning}
-                fillOpacity={0.1}
-                stroke={T.warning}
-                strokeOpacity={0.25}
+                fill={z.color}
+                fillOpacity={0.12}
+                stroke={z.color}
+                strokeOpacity={0.3}
                 strokeDasharray="2 3"
               />
             ))}
@@ -439,20 +454,23 @@ export function CliffCurve({
             Your current income ({fmt(currentGross)})
           </span>
           {pitZones.length > 0 && (
-            <span>
-              <span
-                style={{
-                  display: 'inline-block',
-                  width: 14,
-                  height: 10,
-                  background: T.warning,
-                  opacity: 0.25,
-                  border: `1px dashed ${T.warning}`,
-                  marginRight: 6,
-                  verticalAlign: 'middle',
-                }}
-              />
-              Worse off than at some lower income
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ display: 'inline-flex', gap: 2 }}>
+                {pitZones.map((z, i) => (
+                  <span
+                    key={`pit-swatch-${i}`}
+                    style={{
+                      display: 'inline-block',
+                      width: 12,
+                      height: 10,
+                      background: z.color,
+                      opacity: 0.3,
+                      border: `1px dashed ${z.color}`,
+                    }}
+                  />
+                ))}
+              </span>
+              Worse off than at some lower income (shaded by program lost)
             </span>
           )}
           {cliffs.map((c) => (

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -133,8 +133,27 @@ export function CliffCurve({
     }
 
     // Drop any cliffs the household will never see (e.g. CHIP cutoff above
-    // sweep range, or duplicate income points). Sort low-to-high.
-    return list.filter((c) => c.gross > 0 && c.gross <= maxGross).sort((a, b) => a.gross - b.gross);
+    // sweep range, or duplicate income points). Sort low-to-high, then
+    // assign each cliff a vertical "row" so labels close together on the X
+    // axis stagger upward instead of overprinting each other.
+    const visible = list
+      .filter((c) => c.gross > 0 && c.gross <= maxGross)
+      .sort((a, b) => a.gross - b.gross);
+    // Stagger: each label takes the *lowest* row where it doesn't
+    // horizontally overlap any label already placed at that row. So three
+    // close-together labels go (0, 1, 2), but if the third one is actually
+    // far enough from the first, it drops back to row 0 instead of
+    // climbing forever. Two labels far apart both stay at row 0.
+    const minSpacing = maxGross * 0.1;
+    const placed: { gross: number; row: number }[] = [];
+    return visible.map((c) => {
+      let row = 0;
+      while (placed.some((p) => p.row === row && Math.abs(p.gross - c.gross) < minSpacing)) {
+        row += 1;
+      }
+      placed.push({ gross: c.gross, row });
+      return { ...c, labelRow: row };
+    });
   }, [householdSize, cityData.state, kids, maxGross]);
 
   const userPoint = useMemo(() => {
@@ -194,7 +213,15 @@ export function CliffCurve({
         </div>
 
         <ResponsiveContainer width="100%" height={340}>
-          <LineChart data={points} margin={{ top: 16, right: 24, left: 8, bottom: 16 }}>
+          <LineChart
+            data={points}
+            margin={{
+              top: 20 + Math.max(0, ...cliffs.map((c) => c.labelRow)) * 13,
+              right: 24,
+              left: 8,
+              bottom: 16,
+            }}
+          >
             <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
             <XAxis
               dataKey="gross"
@@ -229,12 +256,21 @@ export function CliffCurve({
                 x={c.gross}
                 stroke={c.color}
                 strokeDasharray="3 3"
-                label={{
-                  value: c.label,
-                  position: 'top',
-                  fill: c.color,
-                  fontSize: 10,
-                  fontFamily: fonts.body,
+                label={(props: { viewBox?: { x?: number; y?: number } }) => {
+                  const x = props.viewBox?.x ?? 0;
+                  const y = props.viewBox?.y ?? 0;
+                  return (
+                    <text
+                      x={x}
+                      y={y - 6 - c.labelRow * 13}
+                      fill={c.color}
+                      fontSize={10}
+                      fontFamily={fonts.body}
+                      textAnchor="middle"
+                    >
+                      {c.label}
+                    </text>
+                  );
                 }}
               />
             ))}

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -134,36 +134,10 @@ export function CliffCurve({
   const stepCount = 240;
   const stepSize = Math.max(500, Math.round(maxGross / stepCount / 500) * 500);
 
-  const points = useMemo(() => {
-    const out: SweepPoint[] = [];
-    for (let g = 0; g <= maxGross; g += stepSize) {
-      const sweepIncomeA = Math.max(0, g - incomeB);
-      const r = computeBudget({
-        incomeA: sweepIncomeA,
-        incomeB,
-        hasPartner,
-        filing,
-        city,
-        kids,
-        lifestyle,
-        claimedBenefits: allBenefits,
-      });
-      const annualBenefits = r.totalBenefits * 12;
-      out.push({
-        gross: g,
-        discretionary: Math.round(r.annualDiscretionary),
-        takeHome: Math.round(r.netIncome),
-        takeHomePlusBenefits: Math.round(r.netIncome + annualBenefits),
-        benefits: Math.round(annualBenefits),
-      });
-    }
-    return out;
-  }, [maxGross, stepSize, incomeB, hasPartner, filing, city, kids, lifestyle, allBenefits]);
-
-  // Cliff thresholds — annual gross income at which each program's
-  // eligibility flips off. Computed from FPL × the program's multiplier
-  // for this household size and state.
-  const cliffs = useMemo(() => {
+  // Cliff threshold metadata (excluding stagger labelRow). Computed first
+  // so the income-sweep loop can inject sample points exactly at each
+  // cliff boundary — see `points` below.
+  const cliffsBase = useMemo(() => {
     const fplBase = fpl(householdSize);
     const list: { id: string; shortLabel: string; label: string; gross: number; color: string }[] =
       [];
@@ -207,11 +181,75 @@ export function CliffCurve({
       });
     }
 
+    return list;
+  }, [householdSize, cityData.state, kids]);
+
+  const points = useMemo(() => {
+    const out: SweepPoint[] = [];
+    // For two-income households the X axis represents the *household*
+    // gross. The fixed partner income is a floor — household gross can't
+    // be less than incomeB. Start the sweep there so the chart never
+    // shows impossible income points (the partner can't earn negative).
+    const startGross = Math.max(0, incomeB);
+    // Inject sample points immediately before and after each cliff so
+    // linear line interpolation produces near-vertical drops AND the
+    // per-cliff caption math reads the actual cliff magnitude rather
+    // than a $500-window-smudged drop that mixes in tax/benefit phaseouts.
+    const sampleGrosses = new Set<number>();
+    for (let g = startGross; g <= maxGross; g += stepSize) sampleGrosses.add(g);
+    for (const c of cliffsBase) {
+      if (c.gross >= startGross && c.gross <= maxGross) {
+        sampleGrosses.add(Math.max(startGross, c.gross - 1));
+        sampleGrosses.add(Math.min(maxGross, c.gross + 1));
+      }
+    }
+    const sortedGrosses = [...sampleGrosses].sort((a, b) => a - b);
+
+    for (const g of sortedGrosses) {
+      const sweepIncomeA = Math.max(0, g - incomeB);
+      const r = computeBudget({
+        incomeA: sweepIncomeA,
+        incomeB,
+        hasPartner,
+        filing,
+        city,
+        kids,
+        lifestyle,
+        claimedBenefits: allBenefits,
+      });
+      const annualBenefits = r.totalBenefits * 12;
+      out.push({
+        gross: g,
+        discretionary: Math.round(r.annualDiscretionary),
+        takeHome: Math.round(r.netIncome),
+        takeHomePlusBenefits: Math.round(r.netIncome + annualBenefits),
+        benefits: Math.round(annualBenefits),
+      });
+    }
+    return out;
+  }, [
+    maxGross,
+    stepSize,
+    incomeB,
+    hasPartner,
+    filing,
+    city,
+    kids,
+    lifestyle,
+    allBenefits,
+    cliffsBase,
+  ]);
+
+  // Stagger the cliffs (assign labelRow per collision check) on top of the
+  // base list. Done as a separate memo since it depends on chartWidthPx
+  // and we don't want to re-run the (expensive) point sweep when the
+  // user resizes the window.
+  const cliffs = useMemo(() => {
     // Drop any cliffs the household will never see (e.g. CHIP cutoff above
     // sweep range, or duplicate income points). Sort low-to-high, then
     // assign each cliff a vertical "row" so labels close together on the X
     // axis stagger upward instead of overprinting each other.
-    const visible = list
+    const visible = cliffsBase
       .filter((c) => c.gross > 0 && c.gross <= maxGross)
       .sort((a, b) => a.gross - b.gross);
     // Stagger: each label takes the *lowest* row where it doesn't
@@ -235,7 +273,7 @@ export function CliffCurve({
       placed.push({ gross: c.gross, halfWidth, row });
       return { ...c, labelRow: row };
     });
-  }, [householdSize, cityData.state, kids, maxGross, chartWidthPx]);
+  }, [cliffsBase, maxGross, chartWidthPx]);
 
   const userPoint = useMemo(() => {
     if (currentGross < 0 || currentGross > maxGross) return null;
@@ -420,7 +458,7 @@ export function CliffCurve({
                 />
               ))}
               <Line
-                type="monotone"
+                type="linear"
                 dataKey={metricMeta.key}
                 stroke={T.ink}
                 strokeWidth={2}

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -1,0 +1,364 @@
+import { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  ReferenceDot,
+  CartesianGrid,
+} from 'recharts';
+import type { TooltipContentProps } from 'recharts/types/component/Tooltip';
+import type { FilingStatus, Lifestyle } from '@/types';
+import { theme as T, fonts, rem } from '@/theme';
+import { fmt } from '@/lib/format';
+import { computeBudget } from '@/lib/budget';
+import { BENEFIT_IDS } from '@/lib/benefits';
+import { fpl } from '@/data/poverty';
+import {
+  MEDICAID_EXPANSION_LIMIT_FPL,
+  STATE_CHIP_LIMIT_FPL,
+  STATE_MEDICAID_POLICY,
+  snapIncomeLimitFpl,
+} from '@/data/benefits';
+import { getCityData } from '@/data/cities';
+import { SectionTitle } from './ui';
+
+/**
+ * Income-sweep view that exposes the discontinuities baked into the safety
+ * net. Holds the household configuration constant (city, kids, filing,
+ * lifestyle) and varies gross income from $0 to $200K, plotting annual
+ * discretionary income at each step. SNAP / Medicaid / CHIP are auto-claimed
+ * during the sweep so the eligibility cliffs are visible — at the threshold
+ * dollar, eligibility flips from yes to no and the curve drops vertically by
+ * the program's annual benefit value.
+ *
+ * For dual-earner households, the sweep varies incomeA only and holds incomeB
+ * fixed. That keeps the X-axis a single household-gross figure that the eye
+ * can map back to the existing inputs.
+ */
+export function CliffCurve({
+  city,
+  kids,
+  filing,
+  lifestyle,
+  hasPartner,
+  incomeA,
+  incomeB,
+}: {
+  city: string;
+  kids: number;
+  filing: FilingStatus;
+  lifestyle: Lifestyle;
+  hasPartner: boolean;
+  incomeA: number;
+  incomeB: number;
+}) {
+  const cityData = getCityData(city);
+  const householdSize = (hasPartner ? 2 : 1) + kids;
+  const allBenefits = useMemo<ReadonlySet<string>>(() => new Set(BENEFIT_IDS), []);
+
+  const currentGross = incomeA + incomeB;
+  // Sweep up to $200K or 1.5× current income, whichever is higher, so the
+  // user's dot is always visible with cliff territory still on screen.
+  const maxGross = Math.max(200_000, Math.ceil((currentGross * 1.5) / 1000) * 1000);
+  const stepCount = 240;
+  const stepSize = Math.max(500, Math.round(maxGross / stepCount / 500) * 500);
+
+  const points = useMemo(() => {
+    const out: { gross: number; discretionary: number; benefits: number }[] = [];
+    for (let g = 0; g <= maxGross; g += stepSize) {
+      const sweepIncomeA = Math.max(0, g - incomeB);
+      const r = computeBudget({
+        incomeA: sweepIncomeA,
+        incomeB,
+        hasPartner,
+        filing,
+        city,
+        kids,
+        lifestyle,
+        claimedBenefits: allBenefits,
+      });
+      out.push({
+        gross: g,
+        discretionary: Math.round(r.annualDiscretionary),
+        benefits: Math.round(r.totalBenefits * 12),
+      });
+    }
+    return out;
+  }, [maxGross, stepSize, incomeB, hasPartner, filing, city, kids, lifestyle, allBenefits]);
+
+  // Cliff thresholds — annual gross income at which each program's
+  // eligibility flips off. Computed from FPL × the program's multiplier
+  // for this household size and state.
+  const cliffs = useMemo(() => {
+    const fplBase = fpl(householdSize);
+    const list: { id: string; label: string; gross: number; color: string }[] = [];
+
+    list.push({
+      id: 'snap',
+      label: 'SNAP',
+      gross: Math.round(fplBase * snapIncomeLimitFpl(cityData.state)),
+      color: T.warning,
+    });
+
+    const policy = STATE_MEDICAID_POLICY[cityData.state];
+    if (policy.expanded) {
+      list.push({
+        id: 'medicaid',
+        label: 'Medicaid (138% FPL)',
+        gross: Math.round(fplBase * MEDICAID_EXPANSION_LIMIT_FPL),
+        color: T.accent,
+      });
+    } else if (kids > 0 && policy.nonExpansionParentLimit !== undefined) {
+      const pct = Math.round(policy.nonExpansionParentLimit * 100);
+      list.push({
+        id: 'medicaid',
+        label: `Medicaid parents (${pct}% FPL)`,
+        gross: Math.round(fplBase * policy.nonExpansionParentLimit),
+        color: T.accent,
+      });
+    }
+
+    if (kids > 0) {
+      const chipLimit = STATE_CHIP_LIMIT_FPL[cityData.state];
+      list.push({
+        id: 'chip',
+        label: `CHIP (${Math.round(chipLimit * 100)}% FPL)`,
+        gross: Math.round(fplBase * chipLimit),
+        color: T.aiAccent,
+      });
+    }
+
+    // Drop any cliffs the household will never see (e.g. CHIP cutoff above
+    // sweep range, or duplicate income points). Sort low-to-high.
+    return list.filter((c) => c.gross > 0 && c.gross <= maxGross).sort((a, b) => a.gross - b.gross);
+  }, [householdSize, cityData.state, kids, maxGross]);
+
+  const userPoint = useMemo(() => {
+    if (currentGross < 0 || currentGross > maxGross) return null;
+    // Find the nearest swept point so the dot lines up with the actual curve.
+    let best = points[0];
+    let bestDist = Math.abs(points[0].gross - currentGross);
+    for (const p of points) {
+      const d = Math.abs(p.gross - currentGross);
+      if (d < bestDist) {
+        best = p;
+        bestDist = d;
+      }
+    }
+    return best;
+  }, [points, currentGross, maxGross]);
+
+  // Quantify each cliff's drop magnitude — useful for the editorial caption.
+  const cliffDrops = useMemo(() => {
+    return cliffs.map((c) => {
+      let before = points[0];
+      for (const p of points) {
+        if (p.gross <= c.gross) before = p;
+        else break;
+      }
+      const after = points.find((p) => p.gross > c.gross) ?? points[points.length - 1];
+      const drop = before.discretionary - after.discretionary;
+      return { ...c, drop };
+    });
+  }, [cliffs, points]);
+
+  const biggestCliff = cliffDrops.reduce<(typeof cliffDrops)[number] | null>(
+    (max, c) => (c.drop > (max?.drop ?? 0) ? c : max),
+    null,
+  );
+
+  return (
+    <div style={{ marginBottom: 48 }}>
+      <SectionTitle kicker="The shape of the safety net">
+        Where one extra dollar costs you thousands
+      </SectionTitle>
+
+      <div style={{ background: T.surface, border: `1px solid ${T.border}`, padding: '20px 16px' }}>
+        <div
+          style={{
+            fontFamily: fonts.body,
+            fontSize: rem(13),
+            color: T.inkSoft,
+            marginBottom: 12,
+            lineHeight: 1.5,
+          }}
+        >
+          Same household in {cityData.name}, {cityData.state} — sweeping gross income from $0 to{' '}
+          {fmt(maxGross)}. The curve is smooth where the tax code phases things in gradually.
+          The vertical drops are <em>cliffs</em>: a single dollar of additional income disqualifies
+          the household from a program entirely.
+        </div>
+
+        <ResponsiveContainer width="100%" height={340}>
+          <LineChart data={points} margin={{ top: 16, right: 24, left: 8, bottom: 16 }}>
+            <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+            <XAxis
+              dataKey="gross"
+              type="number"
+              domain={[0, maxGross]}
+              tickFormatter={(v) => `$${Math.round(v / 1000)}K`}
+              stroke={T.inkMuted}
+              tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
+              label={{
+                value: 'Gross household income',
+                position: 'insideBottom',
+                offset: -8,
+                style: {
+                  fontSize: 11,
+                  fill: T.inkMuted,
+                  fontFamily: fonts.body,
+                  letterSpacing: '0.1em',
+                },
+              }}
+            />
+            <YAxis
+              tickFormatter={(v) => (v === 0 ? '$0' : `$${Math.round(v / 1000)}K`)}
+              stroke={T.inkMuted}
+              tick={{ fontSize: 11, fontFamily: fonts.mono, fill: T.inkSoft }}
+              width={56}
+            />
+            <Tooltip content={(props) => <CliffTooltip {...props} cliffs={cliffs} />} />
+            <ReferenceLine y={0} stroke={T.inkMuted} strokeWidth={1} />
+            {cliffs.map((c) => (
+              <ReferenceLine
+                key={c.id + c.gross}
+                x={c.gross}
+                stroke={c.color}
+                strokeDasharray="3 3"
+                label={{
+                  value: c.label,
+                  position: 'top',
+                  fill: c.color,
+                  fontSize: 10,
+                  fontFamily: fonts.body,
+                }}
+              />
+            ))}
+            <Line
+              type="monotone"
+              dataKey="discretionary"
+              stroke={T.ink}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+            {userPoint && (
+              <ReferenceDot
+                x={userPoint.gross}
+                y={userPoint.discretionary}
+                r={5}
+                fill={T.positive}
+                stroke={T.bg}
+                strokeWidth={2}
+                ifOverflow="visible"
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+
+        <div
+          style={{
+            marginTop: 14,
+            fontFamily: fonts.body,
+            fontSize: rem(12),
+            color: T.inkMuted,
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 16,
+          }}
+        >
+          <span>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 10,
+                height: 10,
+                background: T.positive,
+                borderRadius: '50%',
+                marginRight: 6,
+                verticalAlign: 'middle',
+              }}
+            />
+            Your current income ({fmt(currentGross)})
+          </span>
+          {cliffs.map((c) => (
+            <span key={c.id + c.gross}>
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 14,
+                  height: 0,
+                  borderTop: `2px dashed ${c.color}`,
+                  marginRight: 6,
+                  verticalAlign: 'middle',
+                }}
+              />
+              {c.label} cutoff: {fmt(c.gross)}
+            </span>
+          ))}
+        </div>
+
+        {biggestCliff && biggestCliff.drop > 0 && (
+          <div
+            style={{
+              marginTop: 16,
+              fontFamily: fonts.display,
+              fontSize: rem(16),
+              color: T.inkSoft,
+              fontStyle: 'italic',
+              lineHeight: 1.5,
+            }}
+          >
+            At {fmt(biggestCliff.gross)} of gross income, earning one more dollar costs this
+            household roughly {fmt(biggestCliff.drop)} a year — the value of the {biggestCliff.label}{' '}
+            coverage they no longer qualify for. A raise of less than that leaves them poorer than
+            before.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CliffTooltip({
+  active,
+  payload,
+  label,
+  cliffs,
+}: TooltipContentProps & { cliffs: { id: string; label: string; gross: number }[] }) {
+  if (!active || !payload || !payload.length) return null;
+  const gross = typeof label === 'number' ? label : Number(label);
+  const point = payload[0]?.payload as { discretionary: number; benefits: number } | undefined;
+  if (!point) return null;
+  const activePrograms = cliffs.filter((c) => gross <= c.gross);
+  return (
+    <div
+      style={{
+        background: T.surface,
+        border: `1px solid ${T.border}`,
+        padding: '8px 12px',
+        fontFamily: fonts.body,
+        fontSize: rem(12),
+      }}
+    >
+      <div style={{ color: T.inkMuted, marginBottom: 2 }}>Gross {fmt(gross)}/yr</div>
+      <div style={{ fontFamily: fonts.mono, color: point.discretionary >= 0 ? T.positive : T.accent }}>
+        {fmt(point.discretionary)}/yr discretionary
+      </div>
+      {point.benefits > 0 && (
+        <div style={{ fontFamily: fonts.mono, color: T.inkSoft, marginTop: 2 }}>
+          + {fmt(point.benefits)}/yr in benefits
+        </div>
+      )}
+      {activePrograms.length > 0 && (
+        <div style={{ color: T.inkMuted, marginTop: 4 }}>
+          Eligible: {activePrograms.map((c) => c.id.toUpperCase()).join(', ')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -25,6 +25,7 @@ import {
   snapIncomeLimitFpl,
 } from '@/data/benefits';
 import { getCityData } from '@/data/cities';
+import { computePitZones } from '@/lib/cliffs';
 import { SectionTitle } from './ui';
 
 type MetricId = 'discretionary' | 'takeHome' | 'takeHomePlusBenefits';
@@ -252,47 +253,14 @@ export function CliffCurve({
     });
   }, [cliffs, points, metricMeta]);
 
-  // Pit zones: contiguous income ranges where the household ends up with
-  // less of the active metric than they would at some lower income. Walks
-  // the curve left→right tracking the running max; any point below that
-  // running max is "in a pit." Each zone is attributed to the cliff that
-  // caused it — the highest-gross cliff at or below the zone start —
-  // so the shading color can match that program's accent.
-  const pitZones = useMemo(() => {
-    const sortedCliffs = [...cliffs].sort((a, b) => b.gross - a.gross); // desc
-    const findCauseColor = (zoneStart: number): string => {
-      const cause = sortedCliffs.find((c) => c.gross < zoneStart);
-      return cause?.color ?? T.warning;
-    };
-
-    const zones: { x1: number; x2: number; color: string }[] = [];
-    let runningMax = -Infinity;
-    let currentZoneStart: number | null = null;
-    for (let i = 0; i < points.length; i++) {
-      const v = points[i][metricMeta.key] as number;
-      if (v < runningMax) {
-        if (currentZoneStart === null) currentZoneStart = points[i].gross;
-      } else {
-        if (currentZoneStart !== null) {
-          zones.push({
-            x1: currentZoneStart,
-            x2: points[i].gross,
-            color: findCauseColor(currentZoneStart),
-          });
-          currentZoneStart = null;
-        }
-        runningMax = v;
-      }
-    }
-    if (currentZoneStart !== null) {
-      zones.push({
-        x1: currentZoneStart,
-        x2: points[points.length - 1].gross,
-        color: findCauseColor(currentZoneStart),
-      });
-    }
-    return zones;
-  }, [points, metricMeta, cliffs]);
+  const pitZones = useMemo(
+    () =>
+      computePitZones(points, metricMeta.key, cliffs).map((z) => ({
+        ...z,
+        color: z.color ?? T.warning,
+      })),
+    [points, metricMeta, cliffs],
+  );
 
   return (
     <div style={{ marginBottom: 48 }}>

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -36,24 +36,33 @@ interface SweepPoint {
   benefits: number;
 }
 
-const METRICS: Record<MetricId, { label: string; longLabel: string; key: keyof SweepPoint; unitNoun: string }> = {
+const METRICS: Record<
+  MetricId,
+  { label: string; longLabel: string; key: keyof SweepPoint; unitNoun: string; description: string }
+> = {
   discretionary: {
     label: 'Discretionary',
     longLabel: 'Annual discretionary income',
     key: 'discretionary',
     unitNoun: 'discretionary',
+    description:
+      "What's actually left over each year after taxes and modeled household expenses (rent, groceries, healthcare, childcare, etc.). The most editorial measure, but cliffs read smaller here because losing Medicaid also raises healthcare expense — the two partially cancel.",
   },
   takeHome: {
     label: 'Take-home',
     longLabel: 'Annual take-home pay (net of taxes)',
     key: 'takeHome',
     unitNoun: 'take-home',
+    description:
+      'Gross income minus federal, state, local, and FICA taxes. Ignores expenses entirely. Cliffs are invisible here because benefit value never enters the take-home line — only the tax-bracket and EITC/CTC phaseouts bend the curve.',
   },
   takeHomePlusBenefits: {
     label: 'Take-home + benefits',
     longLabel: 'Annual take-home pay + benefit value',
     key: 'takeHomePlusBenefits',
     unitNoun: 'total resources',
+    description:
+      'Take-home pay plus the dollar value of every safety-net benefit the household qualifies for (Medicaid, CHIP, SNAP). This is the cleanest cliff view: each vertical drop is the pure cash value of the lost program, with no expense smoothing.',
   },
 };
 
@@ -428,34 +437,63 @@ function MetricToggle({
   metric: MetricId;
   onChange: (m: MetricId) => void;
 }) {
+  // Track which button is currently hovered/focused so the description
+  // line below previews that one — falls back to the active metric.
+  const [previewing, setPreviewing] = useState<MetricId | null>(null);
+  const shown = previewing ?? metric;
+
   return (
-    <div role="group" aria-label="Metric to plot" style={{ display: 'inline-flex', gap: 0 }}>
-      {(Object.keys(METRICS) as MetricId[]).map((id, i) => {
-        const isActive = metric === id;
-        return (
-          <button
-            key={id}
-            type="button"
-            onClick={() => onChange(id)}
-            aria-pressed={isActive}
-            style={{
-              fontFamily: fonts.body,
-              fontSize: rem(11),
-              letterSpacing: '0.04em',
-              padding: '6px 10px',
-              border: `1px solid ${isActive ? T.ink : T.border}`,
-              borderLeftWidth: i === 0 ? 1 : 0,
-              background: isActive ? T.ink : T.bg,
-              color: isActive ? T.bg : T.inkSoft,
-              cursor: 'pointer',
-              fontWeight: isActive ? 600 : 400,
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {METRICS[id].label}
-          </button>
-        );
-      })}
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 6 }}>
+      <div role="group" aria-label="Metric to plot" style={{ display: 'inline-flex', gap: 0 }}>
+        {(Object.keys(METRICS) as MetricId[]).map((id, i) => {
+          const isActive = metric === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onChange(id)}
+              onMouseEnter={() => setPreviewing(id)}
+              onMouseLeave={() => setPreviewing(null)}
+              onFocus={() => setPreviewing(id)}
+              onBlur={() => setPreviewing(null)}
+              aria-pressed={isActive}
+              aria-describedby={`metric-${id}-desc`}
+              title={METRICS[id].description}
+              style={{
+                fontFamily: fonts.body,
+                fontSize: rem(11),
+                letterSpacing: '0.04em',
+                padding: '6px 10px',
+                border: `1px solid ${isActive ? T.ink : T.border}`,
+                borderLeftWidth: i === 0 ? 1 : 0,
+                background: isActive ? T.ink : T.bg,
+                color: isActive ? T.bg : T.inkSoft,
+                cursor: 'pointer',
+                fontWeight: isActive ? 600 : 400,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {METRICS[id].label}
+            </button>
+          );
+        })}
+      </div>
+      <div
+        id={`metric-${shown}-desc`}
+        role="status"
+        aria-live="polite"
+        style={{
+          fontFamily: fonts.body,
+          fontSize: rem(11),
+          color: T.inkMuted,
+          maxWidth: 360,
+          textAlign: 'right',
+          lineHeight: 1.5,
+          fontStyle: 'italic',
+        }}
+      >
+        {METRICS[shown].description}
+      </div>
     </div>
   );
 }

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -224,9 +224,11 @@ export function CliffCurve({
     return best;
   }, [points, currentGross, maxGross]);
 
-  // Quantify each cliff's drop magnitude — useful for the editorial caption.
-  // Uses whichever metric the user has selected so the caption matches the
-  // chart line.
+  // Quantify each cliff's drop magnitude AND its recovery income — the
+  // lowest income above the cliff where the curve climbs back up to the
+  // pre-cliff value. If the curve never recovers within the swept range,
+  // recoveryGross is null. Uses whichever metric the user has selected so
+  // the caption matches the chart line.
   const cliffDrops = useMemo(() => {
     return cliffs.map((c) => {
       let before = points[0];
@@ -235,15 +237,20 @@ export function CliffCurve({
         else break;
       }
       const after = points.find((p) => p.gross > c.gross) ?? points[points.length - 1];
-      const drop = (before[metricMeta.key] as number) - (after[metricMeta.key] as number);
-      return { ...c, drop };
+      const beforeValue = before[metricMeta.key] as number;
+      const drop = beforeValue - (after[metricMeta.key] as number);
+      let recoveryGross: number | null = null;
+      if (drop > 0) {
+        for (const p of points) {
+          if (p.gross > c.gross && (p[metricMeta.key] as number) >= beforeValue) {
+            recoveryGross = p.gross;
+            break;
+          }
+        }
+      }
+      return { ...c, drop, recoveryGross };
     });
   }, [cliffs, points, metricMeta]);
-
-  const biggestCliff = cliffDrops.reduce<(typeof cliffDrops)[number] | null>(
-    (max, c) => (c.drop > (max?.drop ?? 0) ? c : max),
-    null,
-  );
 
   // Pit zones: contiguous income ranges where the household ends up with
   // less of the active metric than they would at some lower income. Walks
@@ -465,22 +472,56 @@ export function CliffCurve({
           ))}
         </div>
 
-        {biggestCliff && biggestCliff.drop > 0 && (
-          <div
+        {cliffDrops.some((c) => c.drop > 0) && (
+          <ul
             style={{
               marginTop: 16,
-              fontFamily: fonts.display,
-              fontSize: rem(16),
-              color: T.inkSoft,
-              fontStyle: 'italic',
-              lineHeight: 1.5,
+              padding: 0,
+              listStyle: 'none',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 10,
             }}
           >
-            At {fmt(biggestCliff.gross)} of gross income, earning one more dollar costs this
-            household roughly {fmt(biggestCliff.drop)} a year in {metricMeta.unitNoun} — the value
-            of the {biggestCliff.label} coverage they no longer qualify for. A raise of less than
-            that leaves them poorer than before.
-          </div>
+            {cliffDrops
+              .filter((c) => c.drop > 0)
+              .map((c) => (
+                <li
+                  key={c.id + c.gross}
+                  style={{
+                    fontFamily: fonts.display,
+                    fontSize: rem(15),
+                    color: T.inkSoft,
+                    fontStyle: 'italic',
+                    lineHeight: 1.5,
+                    paddingLeft: 12,
+                    borderLeft: `3px solid ${c.color}`,
+                  }}
+                >
+                  At <strong style={{ color: T.ink, fontStyle: 'normal' }}>{fmt(c.gross)}</strong>,
+                  losing <strong style={{ color: T.ink, fontStyle: 'normal' }}>{c.label}</strong>{' '}
+                  costs roughly{' '}
+                  <strong style={{ color: T.ink, fontStyle: 'normal' }}>
+                    {fmt(c.drop)}/yr
+                  </strong>{' '}
+                  in {metricMeta.unitNoun}.{' '}
+                  {c.recoveryGross !== null ? (
+                    <>
+                      The household isn't back to even until they earn{' '}
+                      <strong style={{ color: T.ink, fontStyle: 'normal' }}>
+                        {fmt(c.recoveryGross)}
+                      </strong>{' '}
+                      — a {fmt(c.recoveryGross - c.gross)} raise that nets them nothing.
+                    </>
+                  ) : (
+                    <>
+                      The curve doesn't recover within the swept range — the household stays
+                      poorer than they were at {fmt(c.gross)} all the way to {fmt(maxGross)}.
+                    </>
+                  )}
+                </li>
+              ))}
+          </ul>
         )}
       </div>
     </div>

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -253,12 +253,12 @@ export function CliffCurve({
     });
   }, [cliffs, points, metricMeta]);
 
+  // Uniform warning tint per /design-lab#compound V5: every pit zone
+  // shaded the same color regardless of which program caused it. Avoids
+  // overclaiming attribution when multiple cliffs contribute to a merged
+  // pit (the compound case has no single "right" attribution).
   const pitZones = useMemo(
-    () =>
-      computePitZones(points, metricMeta.key, cliffs).map((z) => ({
-        ...z,
-        color: z.color ?? T.warning,
-      })),
+    () => computePitZones(points, metricMeta.key, cliffs),
     [points, metricMeta, cliffs],
   );
 
@@ -342,9 +342,9 @@ export function CliffCurve({
                 key={`pit-${i}`}
                 x1={z.x1}
                 x2={z.x2}
-                fill={z.color}
+                fill={T.warning}
                 fillOpacity={0.12}
-                stroke={z.color}
+                stroke={T.warning}
                 strokeOpacity={0.3}
                 strokeDasharray="2 3"
               />
@@ -423,22 +423,17 @@ export function CliffCurve({
           </span>
           {pitZones.length > 0 && (
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-              <span style={{ display: 'inline-flex', gap: 2 }}>
-                {pitZones.map((z, i) => (
-                  <span
-                    key={`pit-swatch-${i}`}
-                    style={{
-                      display: 'inline-block',
-                      width: 12,
-                      height: 10,
-                      background: z.color,
-                      opacity: 0.3,
-                      border: `1px dashed ${z.color}`,
-                    }}
-                  />
-                ))}
-              </span>
-              Worse off than at some lower income (shaded by program lost)
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 14,
+                  height: 10,
+                  background: T.warning,
+                  opacity: 0.3,
+                  border: `1px dashed ${T.warning}`,
+                }}
+              />
+              Worse off than at some lower income
             </span>
           )}
           {cliffs.map((c) => (

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -48,7 +48,7 @@ const METRICS: Record<
     key: 'discretionary',
     unitNoun: 'discretionary',
     description:
-      "What's actually left over each year after taxes and modeled household expenses (rent, groceries, healthcare, childcare, etc.). The most editorial measure, but cliffs read smaller here because losing Medicaid also raises healthcare expense — the two partially cancel.",
+      "What's actually left over each year after taxes and modeled household expenses (rent, groceries, healthcare, childcare, etc.). The most editorial measure — answers \"how much can the household actually spend after the bills are paid?\"",
   },
   takeHome: {
     label: 'Take-home',
@@ -56,7 +56,7 @@ const METRICS: Record<
     key: 'takeHome',
     unitNoun: 'take-home',
     description:
-      'Gross income minus federal, state, local, and FICA taxes. Ignores expenses entirely. Cliffs are invisible here because benefit value never enters the take-home line — only the tax-bracket and EITC/CTC phaseouts bend the curve.',
+      "Gross income minus federal, state, local, and FICA taxes. Ignores expenses and benefits entirely. Benefit cliffs are invisible on this line — only tax-bracket transitions and EITC/CTC phaseouts bend the curve. Useful for separating what the tax code does from what the safety net does.",
   },
   takeHomePlusBenefits: {
     label: 'Take-home + benefits',
@@ -64,7 +64,7 @@ const METRICS: Record<
     key: 'takeHomePlusBenefits',
     unitNoun: 'total resources',
     description:
-      'Take-home pay plus the dollar value of every safety-net benefit the household qualifies for (Medicaid, CHIP, SNAP). This is the cleanest cliff view: each vertical drop is the pure cash value of the lost program, with no expense smoothing.',
+      "Take-home pay plus the dollar value of every safety-net benefit the household qualifies for (Medicaid, CHIP, SNAP). The total cash + in-kind resources reaching the household. Cliffs here are the same size as on Discretionary — both just drop by the value of the lost program — but the baseline runs higher because benefits stack onto take-home instead of getting netted out against expenses.",
   },
 };
 
@@ -102,9 +102,7 @@ export function CliffCurve({
   const householdSize = (hasPartner ? 2 : 1) + kids;
 
   // Measure the chart wrapper so the label-stagger math can convert
-  // pixel-width estimates of each label into gross-dollar minSpacing.
-  // Without this we'd be picking a hand-tuned fraction of maxGross that
-  // either over- or under-bumps depending on label text and sweep range.
+  // pixel widths into gross-dollar minSpacing.
   const chartWrapperRef = useRef<HTMLDivElement | null>(null);
   const [chartWidthPx, setChartWidthPx] = useState(640);
   useEffect(() => {
@@ -117,6 +115,7 @@ export function CliffCurve({
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
+
   const allBenefits = useMemo<ReadonlySet<string>>(() => new Set(BENEFIT_IDS), []);
 
   // Which financial measure to plot on the Y axis. Discretionary is the most
@@ -216,23 +215,14 @@ export function CliffCurve({
       .filter((c) => c.gross > 0 && c.gross <= maxGross)
       .sort((a, b) => a.gross - b.gross);
     // Stagger: each label takes the *lowest* row where it doesn't
-    // horizontally overlap any label already placed at that row. We
-    // compute each label's required horizontal clearance in actual gross
-    // dollars from (a) its rendered pixel width estimate (chars × ~5.5px
-    // at 10px font) and (b) the chart's measured pixel width. The plot
-    // area is narrower than the wrapper because the YAxis eats ~56px on
-    // the left and the right margin eats ~24px; subtract those before
-    // converting. This collapses to per-label clearance instead of a
-    // hand-tuned fraction of maxGross.
-    // Plot area: wrapper minus YAxis (56), right margin (24), left margin (8).
+    // horizontally overlap any label already placed at that row. Per-
+    // label clearance is estimated at ~5.5px per character at the 10px
+    // label font size (close enough for the all-caps short labels we
+    // ship — Medicaid / SNAP / CHIP), converted to gross-dollar
+    // clearance via the measured plot width.
     const plotWidthPx = Math.max(50, chartWidthPx - 56 - 24 - 8);
     const pxPerDollar = plotWidthPx / Math.max(1, maxGross);
-    // Empirical: 10px IBM Plex Sans averages ~5px per char, with no extra
-    // padding before two labels visually touch. Earlier estimate of
-    // 5.5px + 8px padding was over-generous and bumped labels that
-    // actually had room — particularly short ones like "SNAP" sitting
-    // between two longer neighbours.
-    const labelHalfWidthDollars = (label: string) => (label.length * 5) / 2 / pxPerDollar;
+    const labelHalfWidthDollars = (label: string) => (label.length * 5.5) / 2 / pxPerDollar;
     const placed: { gross: number; halfWidth: number; row: number }[] = [];
     return visible.map((c) => {
       const halfWidth = labelHalfWidthDollars(c.shortLabel);

--- a/src/components/CliffCurve.tsx
+++ b/src/components/CliffCurve.tsx
@@ -359,17 +359,36 @@ export function CliffCurve({
                 label={(props: { viewBox?: { x?: number; y?: number } }) => {
                   const x = props.viewBox?.x ?? 0;
                   const y = props.viewBox?.y ?? 0;
+                  // Label sits in the chart's top margin; for bumped rows
+                  // it's even higher up. The ReferenceLine itself only
+                  // draws inside the plot area, so when row > 0 we add a
+                  // matching dashed connector from the chart top up to
+                  // just below the label so the eye can follow line→label.
+                  const labelY = y - 6 - c.labelRow * 13;
                   return (
-                    <text
-                      x={x}
-                      y={y - 6 - c.labelRow * 13}
-                      fill={c.color}
-                      fontSize={10}
-                      fontFamily={fonts.body}
-                      textAnchor="middle"
-                    >
-                      {c.label}
-                    </text>
+                    <g>
+                      {c.labelRow > 0 && (
+                        <line
+                          x1={x}
+                          x2={x}
+                          y1={y}
+                          y2={labelY + 2}
+                          stroke={c.color}
+                          strokeDasharray="3 3"
+                          strokeWidth={1}
+                        />
+                      )}
+                      <text
+                        x={x}
+                        y={labelY}
+                        fill={c.color}
+                        fontSize={10}
+                        fontFamily={fonts.body}
+                        textAnchor="middle"
+                      >
+                        {c.label}
+                      </text>
+                    </g>
                   );
                 }}
               />

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -3942,15 +3942,53 @@ function PitChartBottomBand() {
 //
 // These four variations explore how to expose multi-cliff contribution.
 
-const COMPOUND_SCENARIO: CliffScenario = {
-  city: 'nyc',
-  kids: 0,
-  filing: 'single',
-  lifestyle: 'moderate',
-  hasPartner: false,
-  incomeA: 30000,
-  incomeB: 0,
-};
+// Synthetic curve engineered to clearly exhibit overlapping pits — three
+// cliffs close enough together, with a shallow enough recovery slope,
+// that they merge into one continuous pit zone. Real Columbus scenarios
+// don't reliably overlap (cliffs there are spaced apart relative to
+// recovery slopes), so we synthesize for visual clarity. Cliff positions
+// and labels mirror the Columbus, OH program lineup for editorial
+// continuity with the rest of the lab.
+function useCompoundDemoData(): {
+  points: CliffPoint[];
+  cliffs: CliffMark[];
+  pitZones: PitZone[];
+  maxGross: number;
+  currentGross: number;
+} {
+  return React.useMemo(() => {
+    const maxGross = 80_000;
+    const currentGross = 35_000;
+    const stepSize = 500;
+    // Cliffs deliberately close together with big drops, so recovery from
+    // the first extends past the second and third.
+    const cliffSpecs = [
+      { id: 'medicaid', label: 'Medicaid (138% FPL)', shortLabel: 'Medicaid', gross: 30_000, drop: 5_000, color: CLIFF_COLORS.medicaid },
+      { id: 'snap',     label: 'SNAP (185% FPL)',     shortLabel: 'SNAP',     gross: 40_000, drop: 3_000, color: CLIFF_COLORS.snap     },
+      { id: 'chip',     label: 'CHIP (211% FPL)',     shortLabel: 'CHIP',     gross: 50_000, drop: 5_000, color: CLIFF_COLORS.chip     },
+    ];
+    const slope = 0.3; // shallow enough that recovery spans multiple cliffs
+    const intercept = -1_000;
+
+    const points: CliffPoint[] = [];
+    for (let g = 0; g <= maxGross; g += stepSize) {
+      let disc = slope * g + intercept;
+      for (const c of cliffSpecs) if (g >= c.gross) disc -= c.drop;
+      points.push({ gross: g, discretionary: Math.round(disc) });
+    }
+
+    const cliffs: CliffMark[] = cliffSpecs.map((c) => ({
+      id: c.id,
+      label: c.label,
+      shortLabel: c.shortLabel,
+      gross: c.gross,
+      color: c.color,
+    }));
+    const pitZones = computePitZones(points, 'discretionary', cliffs);
+
+    return { points, cliffs, pitZones, maxGross, currentGross };
+  }, []);
+}
 
 function SectionCompoundPits() {
   return (
@@ -4017,7 +4055,7 @@ function computePerCliffZones(
 }
 
 function CompoundChartSingleColor() {
-  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData();
   return (
     <CompoundFrame>
       <CompoundChartBase
@@ -4032,7 +4070,7 @@ function CompoundChartSingleColor() {
 }
 
 function CompoundChartSplitStriping() {
-  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData();
   const splitZones: PitZone[] = pitZones.flatMap((z) => {
     const interior = cliffs
       .filter((c) => c.gross > z.x1 && c.gross < z.x2)
@@ -4070,7 +4108,7 @@ function CompoundChartSplitStriping() {
 }
 
 function CompoundChartGhost() {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const { points, cliffs, maxGross, currentGross } = useCompoundDemoData();
   const ghostPoints = (() => {
     let runningMax = -Infinity;
     return points.map((p) => {
@@ -4140,7 +4178,7 @@ function CompoundChartGhost() {
 }
 
 function CompoundChartLayered() {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const { points, cliffs, maxGross, currentGross } = useCompoundDemoData();
   const layeredZones = computePerCliffZones(points, cliffs);
   return (
     <CompoundFrame>
@@ -4157,7 +4195,11 @@ function CompoundChartLayered() {
 }
 
 function CompoundFrame({ children }: { children: React.ReactNode }) {
-  return <ScenarioFrame label="NYC · single · no kids · $30K">{children}</ScenarioFrame>;
+  return (
+    <ScenarioFrame label="Synthetic Columbus-style scenario · cliffs at $30K / $40K / $50K (engineered to overlap)">
+      {children}
+    </ScenarioFrame>
+  );
 }
 
 function CompoundChartBase({

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -2088,8 +2088,7 @@ function Section({
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns:
-            columns === 1 ? '1fr' : 'repeat(auto-fit, minmax(420px, 1fr))',
+          gridTemplateColumns: columns === 1 ? '1fr' : 'repeat(auto-fit, minmax(420px, 1fr))',
           gap: 24,
         }}
       >
@@ -2784,16 +2783,9 @@ function SectionCliffAnnotations() {
 /** Renders the variation against the canonical Columbus scenario, which
  *  has all three program cutoffs clustered together — the hard case for
  *  any annotation strategy. */
-function CliffStack({
-  Renderer,
-}: {
-  Renderer: React.ComponentType<CliffScenarioProps>;
-}) {
+function CliffStack({ Renderer }: { Renderer: React.ComponentType<CliffScenarioProps> }) {
   return (
-    <Renderer
-      scenarioLabel="Columbus, OH · HoH · 2 kids · $40K"
-      scenario={CLIFF_SCENARIO_CMH}
-    />
+    <Renderer scenarioLabel="Columbus, OH · HoH · 2 kids · $40K" scenario={CLIFF_SCENARIO_CMH} />
   );
 }
 
@@ -2933,15 +2925,11 @@ function useCliffScenario(scenario: CliffScenario): {
   }, [scenario]);
 }
 
-function ScenarioFrame({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}) {
+function ScenarioFrame({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div style={{ background: T.surface, border: `1px solid ${T.border}`, padding: '12px 12px 8px' }}>
+    <div
+      style={{ background: T.surface, border: `1px solid ${T.border}`, padding: '12px 12px 8px' }}
+    >
       <div
         style={{
           fontSize: rem(10),
@@ -2999,10 +2987,7 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenario
   return (
     <ScenarioFrame label={scenarioLabel}>
       <ResponsiveContainer width="100%" height={220}>
-        <LineChart
-          data={points}
-          margin={{ top: 16 + maxRow * 13, right: 16, left: 0, bottom: 8 }}
-        >
+        <LineChart data={points} margin={{ top: 16 + maxRow * 13, right: 16, left: 0, bottom: 8 }}>
           <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
           <XAxis
             dataKey="gross"
@@ -3062,8 +3047,7 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenario
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3112,14 +3096,7 @@ function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProp
                 const y = (props.viewBox?.y ?? 0) + (props.viewBox?.height ?? 0);
                 return (
                   <g transform={`translate(${x}, ${y + 6})`}>
-                    <rect
-                      x={-32}
-                      y={0}
-                      width={64}
-                      height={16}
-                      fill={c.color}
-                      rx={2}
-                    />
+                    <rect x={-32} y={0} width={64} height={16} fill={c.color} rx={2} />
                     <text
                       x={0}
                       y={11}
@@ -3147,8 +3124,7 @@ function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProp
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3230,8 +3206,7 @@ function CliffChartInlineAtDrop({ scenarioLabel, scenario }: CliffScenarioProps)
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3323,8 +3298,7 @@ function CliffChartNumberedMarkers({ scenarioLabel, scenario }: CliffScenarioPro
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3449,8 +3423,7 @@ function CliffChartColorBands({ scenarioLabel, scenario }: CliffScenarioProps) {
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3585,8 +3558,7 @@ function PitChartTintedArea() {
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3668,8 +3640,7 @@ function PitChartColoredSegment() {
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3688,13 +3659,15 @@ function PitChartGhostLine() {
 
   // Running-max series: at each income, the max discretionary seen at any
   // lower income. The gap between this and the actual curve is the pit.
-  const ghostPoints = (() => {
-    let runningMax = -Infinity;
-    return points.map((p) => {
-      runningMax = Math.max(runningMax, p.discretionary);
-      return { gross: p.gross, ghost: runningMax, actual: p.discretionary };
-    });
-  })();
+  const ghostPoints = points.reduce<{ gross: number; ghost: number; actual: number }[]>(
+    (acc, p) => {
+      const prev = acc.length > 0 ? acc[acc.length - 1].ghost : -Infinity;
+      const ghost = Math.max(prev, p.discretionary);
+      acc.push({ gross: p.gross, ghost, actual: p.discretionary });
+      return acc;
+    },
+    [],
+  );
 
   return (
     <ScenarioFrame label="Columbus, OH · HoH · 2 kids · $40K">
@@ -3744,10 +3717,7 @@ function PitChartGhostLine() {
           />
           <ReferenceDot
             x={currentGross}
-            y={
-              ghostPoints.find((p) => p.gross >= currentGross)?.actual ??
-              ghostPoints[0].actual
-            }
+            y={ghostPoints.find((p) => p.gross >= currentGross)?.actual ?? ghostPoints[0].actual}
             r={4}
             fill={T.positive}
             stroke={T.bg}
@@ -3866,8 +3836,7 @@ function PitChartBottomBand() {
           <ReferenceDot
             x={currentGross}
             y={
-              points.find((p) => p.gross >= currentGross)?.discretionary ??
-              points[0].discretionary
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
             }
             r={4}
             fill={T.positive}
@@ -3880,7 +3849,6 @@ function PitChartBottomBand() {
     </ScenarioFrame>
   );
 }
-
 
 // ── Section: compound pit attribution ────────────────────────────────────
 //
@@ -4154,141 +4122,147 @@ function CompoundConfigPanel({
       </div>
       {!collapsed && (
         <>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'minmax(120px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(120px, 1fr) auto',
-          gap: 8,
-          alignItems: 'center',
-          fontSize: rem(11),
-          marginBottom: 6,
-          color: T.inkMuted,
-          letterSpacing: '0.06em',
-          textTransform: 'uppercase',
-        }}
-      >
-        <span>Label</span>
-        <span>Cliff at ($)</span>
-        <span>Drop ($)</span>
-        <span>Color</span>
-        <span />
-      </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {config.programs.map((p) => (
           <div
-            key={p.id}
             style={{
               display: 'grid',
-              gridTemplateColumns: 'minmax(120px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(120px, 1fr) auto',
+              gridTemplateColumns:
+                'minmax(120px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(120px, 1fr) auto',
               gap: 8,
               alignItems: 'center',
+              fontSize: rem(11),
+              marginBottom: 6,
+              color: T.inkMuted,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
             }}
           >
-            <input
-              type="text"
-              value={p.label}
-              onChange={(e) => updateProgram(p.id, { label: e.target.value })}
-              style={inputStyle}
-            />
-            <input
-              type="number"
-              step={500}
-              value={p.gross}
-              onChange={(e) => updateProgram(p.id, { gross: Number(e.target.value) || 0 })}
-              style={{ ...inputStyle, fontFamily: fonts.mono }}
-            />
-            <input
-              type="number"
-              step={500}
-              value={p.drop}
-              onChange={(e) => updateProgram(p.id, { drop: Number(e.target.value) || 0 })}
-              style={{ ...inputStyle, fontFamily: fonts.mono }}
-            />
-            <select
-              value={p.color}
-              onChange={(e) => updateProgram(p.id, { color: e.target.value })}
-              style={{ ...inputStyle, paddingRight: 4 }}
-            >
-              {COMPOUND_COLOR_CHOICES.map((c) => (
-                <option key={c.id} value={c.value}>
-                  {c.label}
-                </option>
-              ))}
-            </select>
+            <span>Label</span>
+            <span>Cliff at ($)</span>
+            <span>Drop ($)</span>
+            <span>Color</span>
+            <span />
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {config.programs.map((p) => (
+              <div
+                key={p.id}
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns:
+                    'minmax(120px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(120px, 1fr) auto',
+                  gap: 8,
+                  alignItems: 'center',
+                }}
+              >
+                <input
+                  type="text"
+                  value={p.label}
+                  onChange={(e) => updateProgram(p.id, { label: e.target.value })}
+                  style={inputStyle}
+                />
+                <input
+                  type="number"
+                  step={500}
+                  value={p.gross}
+                  onChange={(e) => updateProgram(p.id, { gross: Number(e.target.value) || 0 })}
+                  style={{ ...inputStyle, fontFamily: fonts.mono }}
+                />
+                <input
+                  type="number"
+                  step={500}
+                  value={p.drop}
+                  onChange={(e) => updateProgram(p.id, { drop: Number(e.target.value) || 0 })}
+                  style={{ ...inputStyle, fontFamily: fonts.mono }}
+                />
+                <select
+                  value={p.color}
+                  onChange={(e) => updateProgram(p.id, { color: e.target.value })}
+                  style={{ ...inputStyle, paddingRight: 4 }}
+                >
+                  {COMPOUND_COLOR_CHOICES.map((c) => (
+                    <option key={c.id} value={c.value}>
+                      {c.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => removeProgram(p.id)}
+                  aria-label={`Remove ${p.label}`}
+                  style={{
+                    border: 'none',
+                    background: 'transparent',
+                    color: T.inkMuted,
+                    cursor: 'pointer',
+                    fontSize: rem(14),
+                    padding: '0 6px',
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 10 }}>
             <button
               type="button"
-              onClick={() => removeProgram(p.id)}
-              aria-label={`Remove ${p.label}`}
+              onClick={addProgram}
               style={{
-                border: 'none',
-                background: 'transparent',
-                color: T.inkMuted,
+                border: `1px solid ${T.border}`,
+                background: T.bg,
+                color: T.inkSoft,
+                fontFamily: fonts.body,
+                fontSize: rem(12),
+                padding: '4px 10px',
                 cursor: 'pointer',
-                fontSize: rem(14),
-                padding: '0 6px',
               }}
             >
-              ×
+              + Add program
             </button>
           </div>
-        ))}
-      </div>
-      <div style={{ marginTop: 10 }}>
-        <button
-          type="button"
-          onClick={addProgram}
-          style={{
-            border: `1px solid ${T.border}`,
-            background: T.bg,
-            color: T.inkSoft,
-            fontFamily: fonts.body,
-            fontSize: rem(12),
-            padding: '4px 10px',
-            cursor: 'pointer',
-          }}
-        >
-          + Add program
-        </button>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          gap: 24,
-          alignItems: 'center',
-          marginTop: 14,
-          paddingTop: 12,
-          borderTop: `1px solid ${T.border}`,
-        }}
-      >
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: rem(11) }}>
-          <span style={{ color: T.inkMuted, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
-            Recovery slope ({config.slope.toFixed(2)} disc per $1 gross)
-          </span>
-          <input
-            type="range"
-            min={0.05}
-            max={1}
-            step={0.05}
-            value={config.slope}
-            onChange={(e) => setConfig((c) => ({ ...c, slope: Number(e.target.value) }))}
-            style={{ width: 220 }}
-          />
-        </label>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: rem(11) }}>
-          <span style={{ color: T.inkMuted, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
-            Max gross ({fmtK(config.maxGross)})
-          </span>
-          <input
-            type="range"
-            min={20_000}
-            max={200_000}
-            step={5_000}
-            value={config.maxGross}
-            onChange={(e) => setConfig((c) => ({ ...c, maxGross: Number(e.target.value) }))}
-            style={{ width: 220 }}
-          />
-        </label>
-      </div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 24,
+              alignItems: 'center',
+              marginTop: 14,
+              paddingTop: 12,
+              borderTop: `1px solid ${T.border}`,
+            }}
+          >
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: rem(11) }}>
+              <span
+                style={{ color: T.inkMuted, letterSpacing: '0.06em', textTransform: 'uppercase' }}
+              >
+                Recovery slope ({config.slope.toFixed(2)} disc per $1 gross)
+              </span>
+              <input
+                type="range"
+                min={0.05}
+                max={1}
+                step={0.05}
+                value={config.slope}
+                onChange={(e) => setConfig((c) => ({ ...c, slope: Number(e.target.value) }))}
+                style={{ width: 220 }}
+              />
+            </label>
+            <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: rem(11) }}>
+              <span
+                style={{ color: T.inkMuted, letterSpacing: '0.06em', textTransform: 'uppercase' }}
+              >
+                Max gross ({fmtK(config.maxGross)})
+              </span>
+              <input
+                type="range"
+                min={20_000}
+                max={200_000}
+                step={5_000}
+                value={config.maxGross}
+                onChange={(e) => setConfig((c) => ({ ...c, maxGross: Number(e.target.value) }))}
+                style={{ width: 220 }}
+              />
+            </label>
+          </div>
         </>
       )}
     </div>
@@ -4412,13 +4386,15 @@ function CompoundChartSplitStriping({ config }: { config: CompoundConfig }) {
 
 function CompoundChartGhost({ config }: { config: CompoundConfig }) {
   const { points, cliffs, maxGross, currentGross } = useCompoundDemoData(config);
-  const ghostPoints = (() => {
-    let runningMax = -Infinity;
-    return points.map((p) => {
-      runningMax = Math.max(runningMax, p.discretionary);
-      return { gross: p.gross, ghost: runningMax, actual: p.discretionary };
-    });
-  })();
+  const ghostPoints = points.reduce<{ gross: number; ghost: number; actual: number }[]>(
+    (acc, p) => {
+      const prev = acc.length > 0 ? acc[acc.length - 1].ghost : -Infinity;
+      const ghost = Math.max(prev, p.discretionary);
+      acc.push({ gross: p.gross, ghost, actual: p.discretionary });
+      return acc;
+    },
+    [],
+  );
   return (
     <CompoundFrame>
       <ResponsiveContainer width="100%" height={260}>
@@ -4482,13 +4458,15 @@ function CompoundChartGhost({ config }: { config: CompoundConfig }) {
 
 function CompoundChartGhostShaded({ config }: { config: CompoundConfig }) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
-  const ghostPoints = (() => {
-    let runningMax = -Infinity;
-    return points.map((p) => {
-      runningMax = Math.max(runningMax, p.discretionary);
-      return { gross: p.gross, ghost: runningMax, actual: p.discretionary };
-    });
-  })();
+  const ghostPoints = points.reduce<{ gross: number; ghost: number; actual: number }[]>(
+    (acc, p) => {
+      const prev = acc.length > 0 ? acc[acc.length - 1].ghost : -Infinity;
+      const ghost = Math.max(prev, p.discretionary);
+      acc.push({ gross: p.gross, ghost, actual: p.discretionary });
+      return acc;
+    },
+    [],
+  );
   return (
     <CompoundFrame>
       <ResponsiveContainer width="100%" height={260}>
@@ -4624,9 +4602,7 @@ function ImpactBar({
   maxGross: number;
 }) {
   // Build a sorted list of unique breakpoints (zone starts and ends).
-  const breakpoints = Array.from(
-    new Set(zones.flatMap((z) => [z.x1, z.x2])),
-  ).sort((a, b) => a - b);
+  const breakpoints = Array.from(new Set(zones.flatMap((z) => [z.x1, z.x2]))).sort((a, b) => a - b);
 
   // For each [bp[i], bp[i+1]] window, the active set is every zone
   // that contains the window (zone.x1 < bpEnd AND zone.x2 > bpStart).
@@ -4863,9 +4839,7 @@ function CompoundChartBase({
         />
         <ReferenceDot
           x={currentGross}
-          y={
-            points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
-          }
+          y={points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary}
           r={4}
           fill={T.positive}
           stroke={T.bg}

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -121,7 +121,10 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
     nav: 'Pit-zone presentation',
     count: 4,
     Component: SectionPitZones,
-    status: 'open',
+    status: 'decided',
+    decidedAs: 'V1 — tinted full-height area, uniform warning color',
+    decidedNote:
+      'Per-program tinting was dropped (see compound-pit V5) — every pit zone uses the same warning color now. Hard to miss without overclaiming attribution.',
   },
   {
     id: 'compound',
@@ -3556,8 +3559,9 @@ function SectionPitZones() {
       subhead="Four ways to depict the income ranges where the household ends up with less than they'd have at some lower income. The data is identical; only the visual encoding changes."
     >
       <Variation
+        decided
         title="V1 — Tinted full-height area (current production)"
-        description="ReferenceArea spans the full chart height for each pit, tinted by the program that caused it. Hard to miss; can feel heavy when pits stack up."
+        description="ReferenceArea spans the full chart height for each pit, uniformly tinted in the warning color. Hard to miss; doesn't claim per-program attribution."
       >
         <PitChartTintedArea />
       </Variation>
@@ -3610,9 +3614,9 @@ function PitChartTintedArea() {
               key={i}
               x1={z.x1}
               x2={z.x2}
-              fill={z.color ?? T.warning}
+              fill={T.warning}
               fillOpacity={0.12}
-              stroke={z.color ?? T.warning}
+              stroke={T.warning}
               strokeOpacity={0.3}
               strokeDasharray="2 3"
             />

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -2984,7 +2984,7 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenario
 
   // Stagger: each label takes the lowest row where it doesn't overlap any
   // already-placed label at that row.
-  const minSpacing = maxGross * 0.1;
+  const minSpacing = maxGross * 0.05;
   const placed: { gross: number; row: number }[] = [];
   const annotated = cliffs.map((c) => {
     let row = 0;

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -3942,14 +3942,48 @@ function PitChartBottomBand() {
 //
 // These four variations explore how to expose multi-cliff contribution.
 
-// Synthetic curve engineered to clearly exhibit overlapping pits — three
-// cliffs close enough together, with a shallow enough recovery slope,
-// that they merge into one continuous pit zone. Real Columbus scenarios
-// don't reliably overlap (cliffs there are spaced apart relative to
-// recovery slopes), so we synthesize for visual clarity. Cliff positions
-// and labels mirror the Columbus, OH program lineup for editorial
-// continuity with the rest of the lab.
-function useCompoundDemoData(): {
+// User-editable program config. Each row defines one synthetic cliff: a
+// label, the gross income at which it fires, the dollar drop in
+// discretionary income, and its color. The compound section synthesizes
+// a curve from this list (linear baseline minus accumulated drops) so
+// the user can dial in scenarios that exhibit single pits, merged pits,
+// triple-overlap pits, etc. — and watch each variation respond.
+interface ProgramConfig {
+  id: string;
+  label: string;
+  gross: number;
+  drop: number;
+  color: string;
+}
+
+const COMPOUND_COLOR_CHOICES = [
+  { id: 'medicaid', value: CLIFF_COLORS.medicaid, label: 'Red' },
+  { id: 'snap', value: CLIFF_COLORS.snap, label: 'Orange' },
+  { id: 'chip', value: CLIFF_COLORS.chip, label: 'Slate' },
+  { id: 'positive', value: T.positive, label: 'Green' },
+  { id: 'commercial', value: T.commercialAccent, label: 'Gold' },
+  { id: 'ai', value: T.aiAccent, label: 'Blue' },
+] as const;
+
+const COMPOUND_DEFAULT_PROGRAMS: ProgramConfig[] = [
+  { id: 'p1', label: 'Medicaid', gross: 30_000, drop: 5_000, color: CLIFF_COLORS.medicaid },
+  { id: 'p2', label: 'SNAP', gross: 40_000, drop: 3_000, color: CLIFF_COLORS.snap },
+  { id: 'p3', label: 'CHIP', gross: 50_000, drop: 5_000, color: CLIFF_COLORS.chip },
+];
+
+interface CompoundConfig {
+  programs: ProgramConfig[];
+  slope: number;
+  maxGross: number;
+}
+
+const COMPOUND_DEFAULT_CONFIG: CompoundConfig = {
+  programs: COMPOUND_DEFAULT_PROGRAMS,
+  slope: 0.3,
+  maxGross: 80_000,
+};
+
+function useCompoundDemoData(config: CompoundConfig): {
   points: CliffPoint[];
   cliffs: CliffMark[];
   pitZones: PitZone[];
@@ -3957,73 +3991,297 @@ function useCompoundDemoData(): {
   currentGross: number;
 } {
   return React.useMemo(() => {
-    const maxGross = 80_000;
-    const currentGross = 35_000;
-    const stepSize = 500;
-    // Cliffs deliberately close together with big drops, so recovery from
-    // the first extends past the second and third.
-    const cliffSpecs = [
-      { id: 'medicaid', label: 'Medicaid (138% FPL)', shortLabel: 'Medicaid', gross: 30_000, drop: 5_000, color: CLIFF_COLORS.medicaid },
-      { id: 'snap',     label: 'SNAP (185% FPL)',     shortLabel: 'SNAP',     gross: 40_000, drop: 3_000, color: CLIFF_COLORS.snap     },
-      { id: 'chip',     label: 'CHIP (211% FPL)',     shortLabel: 'CHIP',     gross: 50_000, drop: 5_000, color: CLIFF_COLORS.chip     },
-    ];
-    const slope = 0.3; // shallow enough that recovery spans multiple cliffs
+    const { programs, slope, maxGross } = config;
+    const currentGross = Math.round(maxGross * 0.45);
+    const stepSize = Math.max(250, Math.round(maxGross / 200 / 250) * 250);
     const intercept = -1_000;
 
+    const sortedPrograms = [...programs].sort((a, b) => a.gross - b.gross);
     const points: CliffPoint[] = [];
     for (let g = 0; g <= maxGross; g += stepSize) {
       let disc = slope * g + intercept;
-      for (const c of cliffSpecs) if (g >= c.gross) disc -= c.drop;
+      for (const c of sortedPrograms) if (g >= c.gross) disc -= c.drop;
       points.push({ gross: g, discretionary: Math.round(disc) });
     }
 
-    const cliffs: CliffMark[] = cliffSpecs.map((c) => ({
+    const cliffs: CliffMark[] = sortedPrograms.map((c) => ({
       id: c.id,
       label: c.label,
-      shortLabel: c.shortLabel,
+      shortLabel: c.label,
       gross: c.gross,
       color: c.color,
     }));
     const pitZones = computePitZones(points, 'discretionary', cliffs);
 
     return { points, cliffs, pitZones, maxGross, currentGross };
-  }, []);
+  }, [config]);
 }
 
 function SectionCompoundPits() {
+  const [config, setConfig] = React.useState<CompoundConfig>(COMPOUND_DEFAULT_CONFIG);
+
   return (
     <Section
       columns={1}
       heading="Compound pit attribution"
-      subhead="When two cliffs fire close enough that the household hasn't recovered from the first when the second hits, the resulting pit zone is caused by BOTH programs. Production today colors the merged zone by the first cliff only — losing the second cliff's signal. These four variations expose multi-cliff contribution differently."
+      subhead="When two cliffs fire close enough that the household hasn't recovered from the first when the second hits, the resulting pit zone is caused by BOTH programs. Production today colors the merged zone by the first cliff only — losing the second cliff's signal. Edit the program list below to dial in any scenario; all four variations re-render against your config."
     >
+      <CompoundConfigPanel config={config} setConfig={setConfig} />
       <Variation
         title="V1 — Single-color attribution (current production)"
         description="Whole merged zone gets the first cliff's color. Simple but understates the second cliff's role."
       >
-        <CompoundChartSingleColor />
+        <CompoundChartSingleColor config={config} />
       </Variation>
       <Variation
         title="V2 — Split striping at each contributing cliff"
         description="Walk the merged zone and split at every cliff that fires inside it; each segment gets that cliff's color. The shading reads as 'first Medicaid, then SNAP also dropped you.'"
       >
-        <CompoundChartSplitStriping />
+        <CompoundChartSplitStriping config={config} />
       </Variation>
       <Variation
         title="V3 — Ghost 'best-so-far' line, no shading"
         description="Skip attribution entirely. Render a faded running-max line; the visible gap between actual and ghost IS the pit, and it naturally shows compound depth without choosing colors."
       >
-        <CompoundChartGhost />
+        <CompoundChartGhost config={config} />
       </Variation>
       <Variation
         title="V4 — Per-cliff layered zones (translucent stacking)"
         description="Each cliff opens its own translucent pit zone that closes when the curve recovers to that cliff's pre-cliff value. Overlapping zones stack visually — 'inside both' regions look darker. Shows attribution AND depth."
       >
-        <CompoundChartLayered />
+        <CompoundChartLayered config={config} />
       </Variation>
     </Section>
   );
 }
+
+function CompoundConfigPanel({
+  config,
+  setConfig,
+}: {
+  config: CompoundConfig;
+  setConfig: React.Dispatch<React.SetStateAction<CompoundConfig>>;
+}) {
+  const updateProgram = (id: string, patch: Partial<ProgramConfig>) =>
+    setConfig((c) => ({
+      ...c,
+      programs: c.programs.map((p) => (p.id === id ? { ...p, ...patch } : p)),
+    }));
+  const removeProgram = (id: string) =>
+    setConfig((c) => ({ ...c, programs: c.programs.filter((p) => p.id !== id) }));
+  const addProgram = () => {
+    const nextId = `p${Date.now()}`;
+    const usedColors = new Set(config.programs.map((p) => p.color));
+    const nextColor =
+      COMPOUND_COLOR_CHOICES.find((c) => !usedColors.has(c.value))?.value ?? T.warning;
+    setConfig((c) => ({
+      ...c,
+      programs: [
+        ...c.programs,
+        {
+          id: nextId,
+          label: 'New program',
+          gross: Math.round(c.maxGross * 0.6),
+          drop: 3_000,
+          color: nextColor,
+        },
+      ],
+    }));
+  };
+  const reset = () => setConfig(COMPOUND_DEFAULT_CONFIG);
+
+  return (
+    <div
+      style={{
+        gridColumn: '1 / -1',
+        // Sticky so the config stays in reach as the user scrolls down
+        // through the variations. Top offset clears the page's outer
+        // padding; z-index keeps the panel above variation cards.
+        position: 'sticky',
+        top: 8,
+        zIndex: 4,
+        background: T.bgAlt,
+        border: `1px dashed ${T.border}`,
+        borderRadius: 4,
+        padding: 16,
+        marginBottom: 4,
+        boxShadow: '0 4px 12px rgba(27, 24, 21, 0.08)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <div style={{ fontSize: rem(13), fontWeight: 600, color: T.ink }}>
+          Synthetic scenario config
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            border: 'none',
+            background: 'transparent',
+            color: T.inkMuted,
+            fontSize: rem(11),
+            textDecoration: 'underline',
+            cursor: 'pointer',
+            padding: 0,
+          }}
+        >
+          Reset to defaults
+        </button>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(120px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(120px, 1fr) auto',
+          gap: 8,
+          alignItems: 'center',
+          fontSize: rem(11),
+          marginBottom: 6,
+          color: T.inkMuted,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        }}
+      >
+        <span>Label</span>
+        <span>Cliff at ($)</span>
+        <span>Drop ($)</span>
+        <span>Color</span>
+        <span />
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {config.programs.map((p) => (
+          <div
+            key={p.id}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(120px, 2fr) minmax(100px, 1fr) minmax(100px, 1fr) minmax(120px, 1fr) auto',
+              gap: 8,
+              alignItems: 'center',
+            }}
+          >
+            <input
+              type="text"
+              value={p.label}
+              onChange={(e) => updateProgram(p.id, { label: e.target.value })}
+              style={inputStyle}
+            />
+            <input
+              type="number"
+              step={500}
+              value={p.gross}
+              onChange={(e) => updateProgram(p.id, { gross: Number(e.target.value) || 0 })}
+              style={{ ...inputStyle, fontFamily: fonts.mono }}
+            />
+            <input
+              type="number"
+              step={500}
+              value={p.drop}
+              onChange={(e) => updateProgram(p.id, { drop: Number(e.target.value) || 0 })}
+              style={{ ...inputStyle, fontFamily: fonts.mono }}
+            />
+            <select
+              value={p.color}
+              onChange={(e) => updateProgram(p.id, { color: e.target.value })}
+              style={{ ...inputStyle, paddingRight: 4 }}
+            >
+              {COMPOUND_COLOR_CHOICES.map((c) => (
+                <option key={c.id} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => removeProgram(p.id)}
+              aria-label={`Remove ${p.label}`}
+              style={{
+                border: 'none',
+                background: 'transparent',
+                color: T.inkMuted,
+                cursor: 'pointer',
+                fontSize: rem(14),
+                padding: '0 6px',
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 10 }}>
+        <button
+          type="button"
+          onClick={addProgram}
+          style={{
+            border: `1px solid ${T.border}`,
+            background: T.bg,
+            color: T.inkSoft,
+            fontFamily: fonts.body,
+            fontSize: rem(12),
+            padding: '4px 10px',
+            cursor: 'pointer',
+          }}
+        >
+          + Add program
+        </button>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          gap: 24,
+          alignItems: 'center',
+          marginTop: 14,
+          paddingTop: 12,
+          borderTop: `1px solid ${T.border}`,
+        }}
+      >
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: rem(11) }}>
+          <span style={{ color: T.inkMuted, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Recovery slope ({config.slope.toFixed(2)} disc per $1 gross)
+          </span>
+          <input
+            type="range"
+            min={0.05}
+            max={1}
+            step={0.05}
+            value={config.slope}
+            onChange={(e) => setConfig((c) => ({ ...c, slope: Number(e.target.value) }))}
+            style={{ width: 220 }}
+          />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: rem(11) }}>
+          <span style={{ color: T.inkMuted, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+            Max gross ({fmtK(config.maxGross)})
+          </span>
+          <input
+            type="range"
+            min={20_000}
+            max={200_000}
+            step={5_000}
+            value={config.maxGross}
+            onChange={(e) => setConfig((c) => ({ ...c, maxGross: Number(e.target.value) }))}
+            style={{ width: 220 }}
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  fontFamily: fonts.body,
+  fontSize: rem(12),
+  padding: '4px 6px',
+  border: `1px solid ${T.border}`,
+  background: T.bg,
+  color: T.ink,
+};
 
 /** Each cliff's individual pit zone — runs from that cliff's gross to the
  *  income at which the curve recovers to THAT cliff's pre-cliff value.
@@ -4054,8 +4312,8 @@ function computePerCliffZones(
   return zones;
 }
 
-function CompoundChartSingleColor() {
-  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData();
+function CompoundChartSingleColor({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
   return (
     <CompoundFrame>
       <CompoundChartBase
@@ -4069,8 +4327,8 @@ function CompoundChartSingleColor() {
   );
 }
 
-function CompoundChartSplitStriping() {
-  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData();
+function CompoundChartSplitStriping({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
   const splitZones: PitZone[] = pitZones.flatMap((z) => {
     const interior = cliffs
       .filter((c) => c.gross > z.x1 && c.gross < z.x2)
@@ -4107,8 +4365,8 @@ function CompoundChartSplitStriping() {
   );
 }
 
-function CompoundChartGhost() {
-  const { points, cliffs, maxGross, currentGross } = useCompoundDemoData();
+function CompoundChartGhost({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, maxGross, currentGross } = useCompoundDemoData(config);
   const ghostPoints = (() => {
     let runningMax = -Infinity;
     return points.map((p) => {
@@ -4177,8 +4435,8 @@ function CompoundChartGhost() {
   );
 }
 
-function CompoundChartLayered() {
-  const { points, cliffs, maxGross, currentGross } = useCompoundDemoData();
+function CompoundChartLayered({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, maxGross, currentGross } = useCompoundDemoData(config);
   const layeredZones = computePerCliffZones(points, cliffs);
   return (
     <CompoundFrame>

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -4046,8 +4046,8 @@ function SectionCompoundPits() {
         <CompoundChartGhost config={config} />
       </Variation>
       <Variation
-        title="V4 — Per-cliff layered zones (translucent stacking)"
-        description="Each cliff opens its own translucent pit zone that closes when the curve recovers to that cliff's pre-cliff value. Overlapping zones stack visually — 'inside both' regions look darker. Shows attribution AND depth."
+        title="V4 — Per-cliff pit timeline (Gantt-style lanes)"
+        description="Chart stays clean (no in-chart fills); pit attribution moves to a small per-program timeline below the chart. Each cliff gets its own labeled lane, colored only over the income range where that program contributes to the household being worse off. Comparing lanes vertically tells you which programs overlap and where."
       >
         <CompoundChartLayered config={config} />
       </Variation>
@@ -4496,15 +4496,94 @@ function CompoundChartLayered({ config }: { config: CompoundConfig }) {
   const layeredZones = computePerCliffZones(points, cliffs);
   return (
     <CompoundFrame>
+      {/* Chart stays clean — no in-chart fills. Cliffs as faint reference
+          lines only. The pit attribution lives in the timeline below. */}
       <CompoundChartBase
         points={points}
         cliffs={cliffs}
-        zones={layeredZones}
+        zones={[]}
         maxGross={maxGross}
         currentGross={currentGross}
-        zoneOpacity={0.14}
       />
+      <PitTimeline cliffs={cliffs} zones={layeredZones} maxGross={maxGross} />
     </CompoundFrame>
+  );
+}
+
+/** Per-program pit timeline. One labeled lane per cliff, with a colored
+ *  bar marking the income range over which that program contributes to
+ *  the household being worse off than at some lower income. Reads as a
+ *  Gantt-style timeline aligned to the chart's X axis above. */
+function PitTimeline({
+  cliffs,
+  zones,
+  maxGross,
+}: {
+  cliffs: CliffMark[];
+  zones: PitZone[];
+  maxGross: number;
+}) {
+  // Match the chart's plot-area inset so lane bars line up with chart X.
+  // CompoundChartBase uses YAxis width=48 plus left margin 0 and right
+  // margin 16 plus chart-internal padding ~4px each side.
+  const leftPad = 48 + 4;
+  const rightPad = 16 + 4;
+  return (
+    <div style={{ marginTop: 8, paddingLeft: leftPad, paddingRight: rightPad }}>
+      <div
+        style={{
+          fontSize: rem(10),
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: T.inkMuted,
+          marginBottom: 4,
+        }}
+      >
+        In-pit timeline
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        {cliffs.map((c) => {
+          const zone = zones.find((z) => z.cliffId === c.id);
+          return (
+            <div
+              key={c.id}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '80px 1fr',
+                alignItems: 'center',
+                gap: 8,
+                fontSize: rem(11),
+              }}
+            >
+              <span style={{ color: T.inkSoft, textAlign: 'right' }}>{c.label}</span>
+              <div
+                style={{
+                  position: 'relative',
+                  height: 10,
+                  background: T.bgAlt,
+                  border: `1px solid ${T.border}`,
+                }}
+              >
+                {zone && (
+                  <div
+                    title={`${c.label} pit: ${fmtK(zone.x1)} → ${fmtK(zone.x2)}`}
+                    style={{
+                      position: 'absolute',
+                      left: `${(zone.x1 / maxGross) * 100}%`,
+                      width: `${((zone.x2 - zone.x1) / maxGross) * 100}%`,
+                      top: 0,
+                      bottom: 0,
+                      background: c.color,
+                      opacity: 0.55,
+                    }}
+                  />
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -31,6 +31,7 @@ import type { Source } from '@/types';
 import type { ReviewKind } from '@/lib/sourceStatus';
 import { computeBudget } from '@/lib/budget';
 import { BENEFIT_IDS } from '@/lib/benefits';
+import { computePitZones, type PitZone } from '@/lib/cliffs';
 import { fpl } from '@/data/poverty';
 import {
   MEDICAID_EXPANSION_LIMIT_FPL,
@@ -113,6 +114,13 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
     nav: 'Cliff threshold annotations',
     count: 5,
     Component: SectionCliffAnnotations,
+    status: 'open',
+  },
+  {
+    id: 'pits',
+    nav: 'Pit-zone presentation',
+    count: 4,
+    Component: SectionPitZones,
     status: 'open',
   },
 ];
@@ -2028,10 +2036,15 @@ function ColorPickerRow({
 function Section({
   heading,
   subhead,
+  columns = 'auto',
   children,
 }: {
   heading: string;
   subhead?: string;
+  /** 'auto' = responsive multi-column (default for compact variations).
+   *  1 = single column, full width — for visualization variations that need
+   *  the horizontal room to breathe. */
+  columns?: 'auto' | 1;
   children: React.ReactNode;
 }) {
   // Sort decided variations to the front so the chosen design is the first
@@ -2059,7 +2072,8 @@ function Section({
       <div
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(420px, 1fr))',
+          gridTemplateColumns:
+            columns === 1 ? '1fr' : 'repeat(auto-fit, minmax(420px, 1fr))',
           gap: 24,
         }}
       >
@@ -2710,58 +2724,71 @@ function ShareMockPostData() {
 // with three close cliffs but break down with one or two.
 
 function SectionCliffAnnotations() {
+  const [showPits, setShowPits] = useState(true);
   return (
     <Section
+      columns={1}
       heading="Cliff threshold annotations"
-      subhead="The Medicaid/SNAP/CHIP cutoffs cluster within $25K of each other for a Columbus household. The challenge: identify which vertical line is which program without overprinting labels, eating chart real estate, or burying the curve. Each variation is rendered against two scenarios to test robustness."
+      subhead="The Medicaid/SNAP/CHIP cutoffs cluster within $25K of each other for a Columbus household. The challenge: identify which vertical line is which program without overprinting labels, eating chart real estate, or burying the curve."
     >
+      <SectionToolbar>
+        <ToolbarToggle
+          label="Pit-zone shading"
+          checked={showPits}
+          onChange={setShowPits}
+          hint="The warning-tinted ranges where the household is worse off than at some lower income. Useful to keep on while comparing label strategies; turn off to see the labels alone."
+        />
+      </SectionToolbar>
       <Variation
         title="V1 — Top labels with smart stagger (current production)"
         description="Labels above each ReferenceLine; collisions auto-bump to a higher row. Reads top-down; eye has to travel from label to line."
       >
-        <CliffStack Renderer={CliffChartTopLabelsStaggered} />
+        <CliffStack Renderer={CliffChartTopLabelsStaggered} showPits={showPits} />
       </Variation>
       <Variation
         title="V2 — Bottom-axis tags below the X axis"
         description="Each cutoff gets a small color-coded tag below the axis at the right dollar amount. Chart stays clean above the curve; eye tracks dashed line down to its tag."
       >
-        <CliffStack Renderer={CliffChartBottomAxisTags} />
+        <CliffStack Renderer={CliffChartBottomAxisTags} showPits={showPits} />
       </Variation>
       <Variation
         title="V3 — Inline labels riding the curve at the drop"
         description="Each label sits next to the actual cliff drop on the curve, anchored to the data instead of floating overhead. Self-evidently which line maps to which program."
       >
-        <CliffStack Renderer={CliffChartInlineAtDrop} />
+        <CliffStack Renderer={CliffChartInlineAtDrop} showPits={showPits} />
       </Variation>
       <Variation
         title="V4 — Numbered markers + legend"
         description="Tiny ① ② ③ markers on the curve at each cliff; the legend below decodes them. Maximum chart cleanliness, minimum visual weight."
       >
-        <CliffStack Renderer={CliffChartNumberedMarkers} />
+        <CliffStack Renderer={CliffChartNumberedMarkers} showPits={showPits} />
       </Variation>
       <Variation
         title="V5 — Color-banded eligibility regions"
         description="Soft horizontal background bands shade the income ranges where each program is active. The transitions between bands ARE the cliffs — no separate markers needed. Reads as a stacked-area / state-of-the-world view."
       >
-        <CliffStack Renderer={CliffChartColorBands} />
+        <CliffStack Renderer={CliffChartColorBands} showPits={showPits} />
       </Variation>
     </Section>
   );
 }
 
-/** Wraps any cliff-chart renderer in two stacked scenarios for comparison. */
-function CliffStack({ Renderer }: { Renderer: React.ComponentType<CliffScenarioProps> }) {
+/** Renders the variation against the canonical Columbus scenario, which
+ *  has all three program cutoffs clustered together — the hard case for
+ *  any annotation strategy. */
+function CliffStack({
+  Renderer,
+  showPits,
+}: {
+  Renderer: React.ComponentType<CliffScenarioProps>;
+  showPits?: boolean;
+}) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-      <Renderer
-        scenarioLabel="Columbus, OH · HoH · 2 kids · $40K"
-        scenario={CLIFF_SCENARIO_CMH}
-      />
-      <Renderer
-        scenarioLabel="NYC · single · no kids · $30K"
-        scenario={CLIFF_SCENARIO_NYC}
-      />
-    </div>
+    <Renderer
+      scenarioLabel="Columbus, OH · HoH · 2 kids · $40K"
+      scenario={CLIFF_SCENARIO_CMH}
+      showPits={showPits}
+    />
   );
 }
 
@@ -2778,6 +2805,10 @@ interface CliffScenario {
 interface CliffScenarioProps {
   scenarioLabel: string;
   scenario: CliffScenario;
+  /** When true, render the warning-tinted "worse off than at some lower
+   *  income" zones behind the curve. Lifted out of each variation so the
+   *  whole section shares one toggle. */
+  showPits?: boolean;
 }
 
 const CLIFF_SCENARIO_CMH: CliffScenario = {
@@ -2787,16 +2818,6 @@ const CLIFF_SCENARIO_CMH: CliffScenario = {
   lifestyle: 'moderate',
   hasPartner: false,
   incomeA: 40000,
-  incomeB: 0,
-};
-
-const CLIFF_SCENARIO_NYC: CliffScenario = {
-  city: 'nyc',
-  kids: 0,
-  filing: 'single',
-  lifestyle: 'moderate',
-  hasPartner: false,
-  incomeA: 30000,
   incomeB: 0,
 };
 
@@ -2827,6 +2848,7 @@ interface CliffMark {
 function useCliffScenario(scenario: CliffScenario): {
   points: CliffPoint[];
   cliffs: CliffMark[];
+  pitZones: PitZone[];
   maxGross: number;
   currentGross: number;
 } {
@@ -2896,9 +2918,14 @@ function useCliffScenario(scenario: CliffScenario): {
       });
     }
 
+    const visibleCliffs = cliffs
+      .filter((c) => c.gross > 0 && c.gross <= maxGross)
+      .sort((a, b) => a.gross - b.gross);
+    const pitZones = computePitZones(points, 'discretionary', visibleCliffs);
     return {
       points,
-      cliffs: cliffs.filter((c) => c.gross > 0 && c.gross <= maxGross).sort((a, b) => a.gross - b.gross),
+      cliffs: visibleCliffs,
+      pitZones,
       maxGross,
       currentGross,
     };
@@ -2932,9 +2959,26 @@ function ScenarioFrame({
 
 const fmtK = (v: number) => (v === 0 ? '$0' : `$${Math.round(v / 1000)}K`);
 
+/** Common pit-zone shading used in cliff-annotation variations so they
+ *  reflect what production looks like. Each zone tinted by causing program. */
+function renderPitZones(zones: readonly PitZone[]) {
+  return zones.map((z, i) => (
+    <ReferenceArea
+      key={`pit-${i}`}
+      x1={z.x1}
+      x2={z.x2}
+      fill={z.color ?? T.warning}
+      fillOpacity={0.12}
+      stroke={z.color ?? T.warning}
+      strokeOpacity={0.3}
+      strokeDasharray="2 3"
+    />
+  ));
+}
+
 // V1 — Top labels with smart stagger (mirrors current production)
-function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenarioProps) {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+function CliffChartTopLabelsStaggered({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   // Stagger: each label takes the lowest row where it doesn't overlap any
   // already-placed label at that row.
@@ -2992,6 +3036,7 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenario
               )}
             />
           ))}
+          {showPits ? renderPitZones(pitZones) : null}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3019,8 +3064,8 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenario
 }
 
 // V2 — Bottom-axis tags below the X axis
-function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProps) {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+function CliffChartBottomAxisTags({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   return (
     <ScenarioFrame label={scenarioLabel}>
@@ -3076,6 +3121,7 @@ function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProp
               }}
             />
           ))}
+          {showPits ? renderPitZones(pitZones) : null}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3103,8 +3149,8 @@ function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProp
 }
 
 // V3 — Inline labels at the drop
-function CliffChartInlineAtDrop({ scenarioLabel, scenario }: CliffScenarioProps) {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+function CliffChartInlineAtDrop({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   // For each cliff, find the discretionary value just before the drop —
   // that's where we anchor the label.
@@ -3158,6 +3204,7 @@ function CliffChartInlineAtDrop({ scenarioLabel, scenario }: CliffScenarioProps)
               )}
             />
           ))}
+          {showPits ? renderPitZones(pitZones) : null}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3185,8 +3232,8 @@ function CliffChartInlineAtDrop({ scenarioLabel, scenario }: CliffScenarioProps)
 }
 
 // V4 — Numbered markers + legend
-function CliffChartNumberedMarkers({ scenarioLabel, scenario }: CliffScenarioProps) {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+function CliffChartNumberedMarkers({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   const annotated = cliffs.map((c, i) => {
     let before = points[0];
@@ -3226,6 +3273,7 @@ function CliffChartNumberedMarkers({ scenarioLabel, scenario }: CliffScenarioPro
               strokeOpacity={0.6}
             />
           ))}
+          {showPits ? renderPitZones(pitZones) : null}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3309,8 +3357,8 @@ function CliffChartNumberedMarkers({ scenarioLabel, scenario }: CliffScenarioPro
 }
 
 // V5 — Color-banded eligibility regions
-function CliffChartColorBands({ scenarioLabel, scenario }: CliffScenarioProps) {
-  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+function CliffChartColorBands({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   // Build sorted ascending cutoff list; each "region" is the interval
   // between two consecutive cutoffs (or 0 / maxGross at the bookends).
@@ -3375,6 +3423,7 @@ function CliffChartColorBands({ scenarioLabel, scenario }: CliffScenarioProps) {
             width={48}
           />
           <ReferenceLine y={0} stroke={T.inkMuted} />
+          {showPits ? renderPitZones(pitZones) : null}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3425,3 +3474,452 @@ function CliffChartColorBands({ scenarioLabel, scenario }: CliffScenarioProps) {
     </ScenarioFrame>
   );
 }
+
+// ── Section toolbar primitives ───────────────────────────────────────────
+
+function SectionToolbar({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        gridColumn: '1 / -1',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 16,
+        padding: '10px 14px',
+        marginBottom: 4,
+        background: T.bgAlt,
+        border: `1px dashed ${T.border}`,
+        borderRadius: 4,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function ToolbarToggle({
+  label,
+  hint,
+  checked,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <label
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        cursor: 'pointer',
+        fontSize: rem(12),
+        color: T.inkSoft,
+      }}
+      title={hint}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        style={{ accentColor: T.accent }}
+      />
+      <span style={{ fontWeight: 600, color: T.ink }}>{label}</span>
+      {hint && <span style={{ color: T.inkMuted, fontStyle: 'italic' }}>· {hint.split('.')[0]}</span>}
+    </label>
+  );
+}
+
+// ── Section: pit-zone presentation ───────────────────────────────────────
+//
+// Four ways to depict the income ranges where the household is worse off
+// than at some lower income. All render against the canonical Columbus
+// scenario where two pits exist (Medicaid and CHIP).
+
+function SectionPitZones() {
+  return (
+    <Section
+      columns={1}
+      heading="Pit-zone presentation"
+      subhead="Four ways to depict the income ranges where the household ends up with less than they'd have at some lower income. The data is identical; only the visual encoding changes."
+    >
+      <Variation
+        title="V1 — Tinted full-height area (current production)"
+        description="ReferenceArea spans the full chart height for each pit, tinted by the program that caused it. Hard to miss; can feel heavy when pits stack up."
+      >
+        <PitChartTintedArea />
+      </Variation>
+      <Variation
+        title="V2 — Recolored line segment in the pit"
+        description="Don't shade the background; instead, recolor the curve itself in pit segments to the program's accent. Chart stays clean; the pit is communicated by the line's color change rather than a tint."
+      >
+        <PitChartColoredSegment />
+      </Variation>
+      <Variation
+        title="V3 — Ghost 'best-so-far' line"
+        description="Render a faded line showing the running max of the metric. The visible gap between the actual curve and the ghost IS the pit. Powerful because it visually quantifies depth — you can see exactly how much money is being left on the table."
+      >
+        <PitChartGhostLine />
+      </Variation>
+      <Variation
+        title="V4 — Bottom-band brackets"
+        description="Pit ranges marked only by a small color-coded bracket along the X axis, not as background fill. Maximum chart cleanliness; pits are signaled but don't dominate the visual."
+      >
+        <PitChartBottomBand />
+      </Variation>
+    </Section>
+  );
+}
+
+function PitChartTintedArea() {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(CLIFF_SCENARIO_CMH);
+  return (
+    <ScenarioFrame label="Columbus, OH · HoH · 2 kids · $40K">
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {pitZones.map((z, i) => (
+            <ReferenceArea
+              key={i}
+              x1={z.x1}
+              x2={z.x2}
+              fill={z.color ?? T.warning}
+              fillOpacity={0.12}
+              stroke={z.color ?? T.warning}
+              strokeOpacity={0.3}
+              strokeDasharray="2 3"
+            />
+          ))}
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.7}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+function PitChartColoredSegment() {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(CLIFF_SCENARIO_CMH);
+
+  // Build per-pit "in-segment" series so each can be drawn as its own
+  // colored line on top of the base line. A point belongs to a pit's
+  // segment when its gross is inside the zone.
+  const segments = pitZones.map((z) => ({
+    color: z.color ?? T.warning,
+    data: points.map((p) => ({
+      gross: p.gross,
+      value: p.gross >= z.x1 && p.gross <= z.x2 ? p.discretionary : null,
+    })),
+  }));
+
+  return (
+    <ScenarioFrame label="Columbus, OH · HoH · 2 kids · $40K">
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.5}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeOpacity={0.55}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          {segments.map((seg, i) => (
+            <Line
+              key={i}
+              type="monotone"
+              data={seg.data}
+              dataKey="value"
+              stroke={seg.color}
+              strokeWidth={3}
+              dot={false}
+              isAnimationActive={false}
+              connectNulls={false}
+            />
+          ))}
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+function PitChartGhostLine() {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(CLIFF_SCENARIO_CMH);
+
+  // Running-max series: at each income, the max discretionary seen at any
+  // lower income. The gap between this and the actual curve is the pit.
+  const ghostPoints = (() => {
+    let runningMax = -Infinity;
+    return points.map((p) => {
+      runningMax = Math.max(runningMax, p.discretionary);
+      return { gross: p.gross, ghost: runningMax, actual: p.discretionary };
+    });
+  })();
+
+  return (
+    <ScenarioFrame label="Columbus, OH · HoH · 2 kids · $40K">
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={ghostPoints} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.5}
+            />
+          ))}
+          <Line
+            type="stepAfter"
+            dataKey="ghost"
+            stroke={T.warning}
+            strokeWidth={1.5}
+            strokeDasharray="4 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="actual"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              ghostPoints.find((p) => p.gross >= currentGross)?.actual ??
+              ghostPoints[0].actual
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <div
+        style={{
+          fontSize: rem(11),
+          color: T.inkMuted,
+          marginTop: 6,
+          display: 'flex',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 14,
+              height: 0,
+              borderTop: `2px solid ${T.ink}`,
+              marginRight: 6,
+              verticalAlign: 'middle',
+            }}
+          />
+          Actual discretionary
+        </span>
+        <span>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 14,
+              height: 0,
+              borderTop: `1.5px dashed ${T.warning}`,
+              marginRight: 6,
+              verticalAlign: 'middle',
+            }}
+          />
+          Best-so-far (running max)
+        </span>
+      </div>
+    </ScenarioFrame>
+  );
+}
+
+function PitChartBottomBand() {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(CLIFF_SCENARIO_CMH);
+  return (
+    <ScenarioFrame label="Columbus, OH · HoH · 2 kids · $40K">
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 28 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.6}
+            />
+          ))}
+          {pitZones.map((z, i) => {
+            // Render a small "[==]" bracket at the bottom of the chart
+            // spanning the pit range. Uses ReferenceLine with a custom
+            // SVG label to avoid pulling in extra primitives.
+            const color = z.color ?? T.warning;
+            return (
+              <ReferenceLine
+                key={i}
+                segment={[
+                  { x: z.x1, y: 0 },
+                  { x: z.x2, y: 0 },
+                ]}
+                stroke={color}
+                strokeWidth={4}
+                ifOverflow="visible"
+                label={(props: { viewBox?: { x?: number; y?: number; width?: number } }) => {
+                  const cx = (props.viewBox?.x ?? 0) + (props.viewBox?.width ?? 0) / 2;
+                  const y = (props.viewBox?.y ?? 0) + 16;
+                  return (
+                    <text x={cx} y={y} textAnchor="middle" fill={color} fontSize={10}>
+                      pit
+                    </text>
+                  );
+                }}
+              />
+            );
+          })}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -2737,50 +2737,41 @@ function ShareMockPostData() {
 // with three close cliffs but break down with one or two.
 
 function SectionCliffAnnotations() {
-  const [showPits, setShowPits] = useState(true);
   return (
     <Section
       columns={1}
       heading="Cliff threshold annotations"
       subhead="The Medicaid/SNAP/CHIP cutoffs cluster within $25K of each other for a Columbus household. The challenge: identify which vertical line is which program without overprinting labels, eating chart real estate, or burying the curve."
     >
-      <SectionToolbar>
-        <ToolbarToggle
-          label="Pit-zone shading"
-          checked={showPits}
-          onChange={setShowPits}
-          hint="The warning-tinted ranges where the household is worse off than at some lower income. Useful to keep on while comparing label strategies; turn off to see the labels alone."
-        />
-      </SectionToolbar>
       <Variation
         title="V1 — Top labels with smart stagger (current production)"
         description="Labels above each ReferenceLine; collisions auto-bump to a higher row. Reads top-down; eye has to travel from label to line."
       >
-        <CliffStack Renderer={CliffChartTopLabelsStaggered} showPits={showPits} />
+        <CliffStack Renderer={CliffChartTopLabelsStaggered} />
       </Variation>
       <Variation
         title="V2 — Bottom-axis tags below the X axis"
         description="Each cutoff gets a small color-coded tag below the axis at the right dollar amount. Chart stays clean above the curve; eye tracks dashed line down to its tag."
       >
-        <CliffStack Renderer={CliffChartBottomAxisTags} showPits={showPits} />
+        <CliffStack Renderer={CliffChartBottomAxisTags} />
       </Variation>
       <Variation
         title="V3 — Inline labels riding the curve at the drop"
         description="Each label sits next to the actual cliff drop on the curve, anchored to the data instead of floating overhead. Self-evidently which line maps to which program."
       >
-        <CliffStack Renderer={CliffChartInlineAtDrop} showPits={showPits} />
+        <CliffStack Renderer={CliffChartInlineAtDrop} />
       </Variation>
       <Variation
         title="V4 — Numbered markers + legend"
         description="Tiny ① ② ③ markers on the curve at each cliff; the legend below decodes them. Maximum chart cleanliness, minimum visual weight."
       >
-        <CliffStack Renderer={CliffChartNumberedMarkers} showPits={showPits} />
+        <CliffStack Renderer={CliffChartNumberedMarkers} />
       </Variation>
       <Variation
         title="V5 — Color-banded eligibility regions"
         description="Soft horizontal background bands shade the income ranges where each program is active. The transitions between bands ARE the cliffs — no separate markers needed. Reads as a stacked-area / state-of-the-world view."
       >
-        <CliffStack Renderer={CliffChartColorBands} showPits={showPits} />
+        <CliffStack Renderer={CliffChartColorBands} />
       </Variation>
     </Section>
   );
@@ -2791,16 +2782,13 @@ function SectionCliffAnnotations() {
  *  any annotation strategy. */
 function CliffStack({
   Renderer,
-  showPits,
 }: {
   Renderer: React.ComponentType<CliffScenarioProps>;
-  showPits?: boolean;
 }) {
   return (
     <Renderer
       scenarioLabel="Columbus, OH · HoH · 2 kids · $40K"
       scenario={CLIFF_SCENARIO_CMH}
-      showPits={showPits}
     />
   );
 }
@@ -2818,10 +2806,6 @@ interface CliffScenario {
 interface CliffScenarioProps {
   scenarioLabel: string;
   scenario: CliffScenario;
-  /** When true, render the warning-tinted "worse off than at some lower
-   *  income" zones behind the curve. Lifted out of each variation so the
-   *  whole section shares one toggle. */
-  showPits?: boolean;
 }
 
 const CLIFF_SCENARIO_CMH: CliffScenario = {
@@ -2973,16 +2957,17 @@ function ScenarioFrame({
 const fmtK = (v: number) => (v === 0 ? '$0' : `$${Math.round(v / 1000)}K`);
 
 /** Common pit-zone shading used in cliff-annotation variations so they
- *  reflect what production looks like. Each zone tinted by causing program. */
+ *  reflect production. Uniform warning color per the decided pit-zone
+ *  presentation (V1 uniform). */
 function renderPitZones(zones: readonly PitZone[]) {
   return zones.map((z, i) => (
     <ReferenceArea
       key={`pit-${i}`}
       x1={z.x1}
       x2={z.x2}
-      fill={z.color ?? T.warning}
+      fill={T.warning}
       fillOpacity={0.12}
-      stroke={z.color ?? T.warning}
+      stroke={T.warning}
       strokeOpacity={0.3}
       strokeDasharray="2 3"
     />
@@ -2990,7 +2975,7 @@ function renderPitZones(zones: readonly PitZone[]) {
 }
 
 // V1 — Top labels with smart stagger (mirrors current production)
-function CliffChartTopLabelsStaggered({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenarioProps) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   // Stagger: each label takes the lowest row where it doesn't overlap any
@@ -3049,7 +3034,7 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario, showPits }: Cli
               )}
             />
           ))}
-          {showPits ? renderPitZones(pitZones) : null}
+          {renderPitZones(pitZones)}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3077,7 +3062,7 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario, showPits }: Cli
 }
 
 // V2 — Bottom-axis tags below the X axis
-function CliffChartBottomAxisTags({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProps) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   return (
@@ -3134,7 +3119,7 @@ function CliffChartBottomAxisTags({ scenarioLabel, scenario, showPits }: CliffSc
               }}
             />
           ))}
-          {showPits ? renderPitZones(pitZones) : null}
+          {renderPitZones(pitZones)}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3162,7 +3147,7 @@ function CliffChartBottomAxisTags({ scenarioLabel, scenario, showPits }: CliffSc
 }
 
 // V3 — Inline labels at the drop
-function CliffChartInlineAtDrop({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+function CliffChartInlineAtDrop({ scenarioLabel, scenario }: CliffScenarioProps) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   // For each cliff, find the discretionary value just before the drop —
@@ -3217,7 +3202,7 @@ function CliffChartInlineAtDrop({ scenarioLabel, scenario, showPits }: CliffScen
               )}
             />
           ))}
-          {showPits ? renderPitZones(pitZones) : null}
+          {renderPitZones(pitZones)}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3245,7 +3230,7 @@ function CliffChartInlineAtDrop({ scenarioLabel, scenario, showPits }: CliffScen
 }
 
 // V4 — Numbered markers + legend
-function CliffChartNumberedMarkers({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+function CliffChartNumberedMarkers({ scenarioLabel, scenario }: CliffScenarioProps) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   const annotated = cliffs.map((c, i) => {
@@ -3286,7 +3271,7 @@ function CliffChartNumberedMarkers({ scenarioLabel, scenario, showPits }: CliffS
               strokeOpacity={0.6}
             />
           ))}
-          {showPits ? renderPitZones(pitZones) : null}
+          {renderPitZones(pitZones)}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3370,7 +3355,7 @@ function CliffChartNumberedMarkers({ scenarioLabel, scenario, showPits }: CliffS
 }
 
 // V5 — Color-banded eligibility regions
-function CliffChartColorBands({ scenarioLabel, scenario, showPits }: CliffScenarioProps) {
+function CliffChartColorBands({ scenarioLabel, scenario }: CliffScenarioProps) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(scenario);
 
   // Build sorted ascending cutoff list; each "region" is the interval
@@ -3436,7 +3421,7 @@ function CliffChartColorBands({ scenarioLabel, scenario, showPits }: CliffScenar
             width={48}
           />
           <ReferenceLine y={0} stroke={T.inkMuted} />
-          {showPits ? renderPitZones(pitZones) : null}
+          {renderPitZones(pitZones)}
           <Line
             type="monotone"
             dataKey="discretionary"
@@ -3485,63 +3470,6 @@ function CliffChartColorBands({ scenarioLabel, scenario, showPits }: CliffScenar
         ))}
       </div>
     </ScenarioFrame>
-  );
-}
-
-// ── Section toolbar primitives ───────────────────────────────────────────
-
-function SectionToolbar({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      style={{
-        gridColumn: '1 / -1',
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 16,
-        padding: '10px 14px',
-        marginBottom: 4,
-        background: T.bgAlt,
-        border: `1px dashed ${T.border}`,
-        borderRadius: 4,
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function ToolbarToggle({
-  label,
-  hint,
-  checked,
-  onChange,
-}: {
-  label: string;
-  hint?: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}) {
-  return (
-    <label
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 8,
-        cursor: 'pointer',
-        fontSize: rem(12),
-        color: T.inkSoft,
-      }}
-      title={hint}
-    >
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        style={{ accentColor: T.accent }}
-      />
-      <span style={{ fontWeight: 600, color: T.ink }}>{label}</span>
-      {hint && <span style={{ color: T.inkMuted, fontStyle: 'italic' }}>· {hint.split('.')[0]}</span>}
-    </label>
   );
 }
 

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -114,7 +114,10 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
     nav: 'Cliff threshold annotations',
     count: 5,
     Component: SectionCliffAnnotations,
-    status: 'open',
+    status: 'decided',
+    decidedAs: 'V1 — top labels with smart stagger',
+    decidedNote:
+      'Lowest-row collision-avoidance keeps labels readable when cliffs cluster. Dashed cliff line now extends up to the label so the eye can follow line→label even on bumped rows.',
   },
   {
     id: 'pits',
@@ -2744,8 +2747,9 @@ function SectionCliffAnnotations() {
       subhead="The Medicaid/SNAP/CHIP cutoffs cluster within $25K of each other for a Columbus household. The challenge: identify which vertical line is which program without overprinting labels, eating chart real estate, or burying the curve."
     >
       <Variation
+        decided
         title="V1 — Top labels with smart stagger (current production)"
-        description="Labels above each ReferenceLine; collisions auto-bump to a higher row. Reads top-down; eye has to travel from label to line."
+        description="Labels above each ReferenceLine; collisions auto-bump to a higher row. The dashed cliff line extends up to bumped labels so the eye can follow line→label."
       >
         <CliffStack Renderer={CliffChartTopLabelsStaggered} />
       </Variation>
@@ -3021,17 +3025,29 @@ function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenario
               x={c.gross}
               stroke={c.color}
               strokeDasharray="3 3"
-              label={(props: { viewBox?: { x?: number; y?: number } }) => (
-                <text
-                  x={props.viewBox?.x ?? 0}
-                  y={(props.viewBox?.y ?? 0) - 4 - c.row * 13}
-                  fill={c.color}
-                  fontSize={10}
-                  textAnchor="middle"
-                >
-                  {c.shortLabel}
-                </text>
-              )}
+              label={(props: { viewBox?: { x?: number; y?: number } }) => {
+                const x = props.viewBox?.x ?? 0;
+                const y = props.viewBox?.y ?? 0;
+                const labelY = y - 4 - c.row * 13;
+                return (
+                  <g>
+                    {c.row > 0 && (
+                      <line
+                        x1={x}
+                        x2={x}
+                        y1={y}
+                        y2={labelY + 2}
+                        stroke={c.color}
+                        strokeDasharray="3 3"
+                        strokeWidth={1}
+                      />
+                    )}
+                    <text x={x} y={labelY} fill={c.color} fontSize={10} textAnchor="middle">
+                      {c.shortLabel}
+                    </text>
+                  </g>
+                );
+              }}
             />
           ))}
           {renderPitZones(pitZones)}

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -123,6 +123,13 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
     Component: SectionPitZones,
     status: 'open',
   },
+  {
+    id: 'compound',
+    nav: 'Compound pit attribution',
+    count: 4,
+    Component: SectionCompoundPits,
+    status: 'open',
+  },
 ];
 
 export function DesignLab({ onBack }: { onBack: () => void }) {
@@ -3923,3 +3930,311 @@ function PitChartBottomBand() {
   );
 }
 
+
+// ── Section: compound pit attribution ────────────────────────────────────
+//
+// When two cliffs fire close enough together that the curve hasn't
+// recovered from the first by the time the second hits, the household's
+// pit "merges" into one continuous zone driven by both programs. The
+// production code attributes that whole zone to the first cliff's color
+// (because it walks left→right and only records the cliff that opened
+// the zone), making the second cliff's contribution invisible.
+//
+// These four variations explore how to expose multi-cliff contribution.
+
+const COMPOUND_SCENARIO: CliffScenario = {
+  city: 'nyc',
+  kids: 0,
+  filing: 'single',
+  lifestyle: 'moderate',
+  hasPartner: false,
+  incomeA: 30000,
+  incomeB: 0,
+};
+
+function SectionCompoundPits() {
+  return (
+    <Section
+      columns={1}
+      heading="Compound pit attribution"
+      subhead="When two cliffs fire close enough that the household hasn't recovered from the first when the second hits, the resulting pit zone is caused by BOTH programs. Production today colors the merged zone by the first cliff only — losing the second cliff's signal. These four variations expose multi-cliff contribution differently."
+    >
+      <Variation
+        title="V1 — Single-color attribution (current production)"
+        description="Whole merged zone gets the first cliff's color. Simple but understates the second cliff's role."
+      >
+        <CompoundChartSingleColor />
+      </Variation>
+      <Variation
+        title="V2 — Split striping at each contributing cliff"
+        description="Walk the merged zone and split at every cliff that fires inside it; each segment gets that cliff's color. The shading reads as 'first Medicaid, then SNAP also dropped you.'"
+      >
+        <CompoundChartSplitStriping />
+      </Variation>
+      <Variation
+        title="V3 — Ghost 'best-so-far' line, no shading"
+        description="Skip attribution entirely. Render a faded running-max line; the visible gap between actual and ghost IS the pit, and it naturally shows compound depth without choosing colors."
+      >
+        <CompoundChartGhost />
+      </Variation>
+      <Variation
+        title="V4 — Per-cliff layered zones (translucent stacking)"
+        description="Each cliff opens its own translucent pit zone that closes when the curve recovers to that cliff's pre-cliff value. Overlapping zones stack visually — 'inside both' regions look darker. Shows attribution AND depth."
+      >
+        <CompoundChartLayered />
+      </Variation>
+    </Section>
+  );
+}
+
+/** Each cliff's individual pit zone — runs from that cliff's gross to the
+ *  income at which the curve recovers to THAT cliff's pre-cliff value.
+ *  Used by V4 for layered overlapping zones. */
+function computePerCliffZones(
+  points: readonly CliffPoint[],
+  cliffs: readonly CliffMark[],
+): PitZone[] {
+  const zones: PitZone[] = [];
+  for (const c of cliffs) {
+    let beforeIdx = 0;
+    for (let i = 0; i < points.length; i++) {
+      if (points[i].gross <= c.gross) beforeIdx = i;
+      else break;
+    }
+    const beforeValue = points[beforeIdx].discretionary;
+    let recoveryGross: number | null = null;
+    for (let i = beforeIdx + 1; i < points.length; i++) {
+      if (points[i].discretionary >= beforeValue) {
+        recoveryGross = points[i].gross;
+        break;
+      }
+    }
+    if (recoveryGross !== null && recoveryGross > c.gross) {
+      zones.push({ x1: c.gross, x2: recoveryGross, color: c.color, cliffId: c.id });
+    }
+  }
+  return zones;
+}
+
+function CompoundChartSingleColor() {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  return (
+    <CompoundFrame>
+      <CompoundChartBase
+        points={points}
+        cliffs={cliffs}
+        zones={pitZones}
+        maxGross={maxGross}
+        currentGross={currentGross}
+      />
+    </CompoundFrame>
+  );
+}
+
+function CompoundChartSplitStriping() {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const splitZones: PitZone[] = pitZones.flatMap((z) => {
+    const interior = cliffs
+      .filter((c) => c.gross > z.x1 && c.gross < z.x2)
+      .sort((a, b) => a.gross - b.gross);
+    if (interior.length === 0) return [z];
+    const breakpoints = [z.x1, ...interior.map((c) => c.gross), z.x2];
+    const subs: PitZone[] = [];
+    for (let i = 0; i < breakpoints.length - 1; i++) {
+      const subStart = breakpoints[i];
+      const subEnd = breakpoints[i + 1];
+      const owner = [...cliffs]
+        .filter((c) => c.gross <= subStart)
+        .sort((a, b) => b.gross - a.gross)[0];
+      subs.push({
+        x1: subStart,
+        x2: subEnd,
+        color: owner?.color ?? z.color,
+        cliffId: owner?.id ?? z.cliffId,
+      });
+    }
+    return subs;
+  });
+  return (
+    <CompoundFrame>
+      <CompoundChartBase
+        points={points}
+        cliffs={cliffs}
+        zones={splitZones}
+        maxGross={maxGross}
+        currentGross={currentGross}
+        zoneOpacity={0.18}
+      />
+    </CompoundFrame>
+  );
+}
+
+function CompoundChartGhost() {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const ghostPoints = (() => {
+    let runningMax = -Infinity;
+    return points.map((p) => {
+      runningMax = Math.max(runningMax, p.discretionary);
+      return { gross: p.gross, ghost: runningMax, actual: p.discretionary };
+    });
+  })();
+  return (
+    <CompoundFrame>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={ghostPoints} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.6}
+            />
+          ))}
+          <Line
+            type="stepAfter"
+            dataKey="ghost"
+            stroke={T.warning}
+            strokeWidth={1.5}
+            strokeDasharray="4 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="actual"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={ghostPoints.find((p) => p.gross >= currentGross)?.actual ?? ghostPoints[0].actual}
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </CompoundFrame>
+  );
+}
+
+function CompoundChartLayered() {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(COMPOUND_SCENARIO);
+  const layeredZones = computePerCliffZones(points, cliffs);
+  return (
+    <CompoundFrame>
+      <CompoundChartBase
+        points={points}
+        cliffs={cliffs}
+        zones={layeredZones}
+        maxGross={maxGross}
+        currentGross={currentGross}
+        zoneOpacity={0.14}
+      />
+    </CompoundFrame>
+  );
+}
+
+function CompoundFrame({ children }: { children: React.ReactNode }) {
+  return <ScenarioFrame label="NYC · single · no kids · $30K">{children}</ScenarioFrame>;
+}
+
+function CompoundChartBase({
+  points,
+  cliffs,
+  zones,
+  maxGross,
+  currentGross,
+  zoneOpacity = 0.15,
+}: {
+  points: CliffPoint[];
+  cliffs: CliffMark[];
+  zones: PitZone[];
+  maxGross: number;
+  currentGross: number;
+  zoneOpacity?: number;
+}) {
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+        <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+        <XAxis
+          dataKey="gross"
+          type="number"
+          domain={[0, maxGross]}
+          tickFormatter={fmtK}
+          stroke={T.inkMuted}
+          tick={{ fontSize: 10, fill: T.inkSoft }}
+        />
+        <YAxis
+          tickFormatter={fmtK}
+          stroke={T.inkMuted}
+          tick={{ fontSize: 10, fill: T.inkSoft }}
+          width={48}
+        />
+        <ReferenceLine y={0} stroke={T.inkMuted} />
+        {zones.map((z, i) => (
+          <ReferenceArea
+            key={i}
+            x1={z.x1}
+            x2={z.x2}
+            fill={z.color ?? T.warning}
+            fillOpacity={zoneOpacity}
+            stroke={z.color ?? T.warning}
+            strokeOpacity={0.3}
+            strokeDasharray="2 3"
+          />
+        ))}
+        {cliffs.map((c) => (
+          <ReferenceLine
+            key={c.id}
+            x={c.gross}
+            stroke={c.color}
+            strokeDasharray="3 3"
+            strokeOpacity={0.7}
+          />
+        ))}
+        <Line
+          type="monotone"
+          dataKey="discretionary"
+          stroke={T.ink}
+          strokeWidth={2}
+          dot={false}
+          isAnimationActive={false}
+        />
+        <ReferenceDot
+          x={currentGross}
+          y={
+            points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
+          }
+          r={4}
+          fill={T.positive}
+          stroke={T.bg}
+          strokeWidth={2}
+          ifOverflow="visible"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -126,7 +126,7 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
   {
     id: 'compound',
     nav: 'Compound pit attribution',
-    count: 6,
+    count: 7,
     Component: SectionCompoundPits,
     status: 'decided',
     decidedAs: 'V5 — uniform warning color, no per-program attribution',
@@ -4067,6 +4067,12 @@ function SectionCompoundPits() {
       >
         <CompoundChartGhostShaded config={config} />
       </Variation>
+      <Variation
+        title="V7 — Slim impact bar below the chart, crosshatched on overlap"
+        description="Chart stays as V5 (uniform tint); a thin bar pinned below the X axis shows each program's impact zone in its own color. Where two impact zones overlap, the segment uses a diagonal crosshatch combining both colors. Triple overlap = three-color hatch. Attribution lives in the bar; the chart stays calm."
+      >
+        <CompoundChartImpactBar config={config} />
+      </Variation>
     </Section>
   );
 }
@@ -4623,6 +4629,128 @@ function CompoundChartLayered({ config }: { config: CompoundConfig }) {
       <PitTimeline cliffs={cliffs} zones={layeredZones} maxGross={maxGross} />
     </CompoundFrame>
   );
+}
+
+function CompoundChartImpactBar({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
+  const impactZones = computePerCliffZones(points, cliffs);
+  return (
+    <CompoundFrame>
+      <CompoundChartBase
+        points={points}
+        cliffs={cliffs}
+        zones={pitZones}
+        maxGross={maxGross}
+        currentGross={currentGross}
+      />
+      <ImpactBar cliffs={cliffs} zones={impactZones} maxGross={maxGross} />
+    </CompoundFrame>
+  );
+}
+
+/** Single thin "impact bar" pinned below the chart. Walks every program's
+ *  impact zone (cliff → recovery), finds breakpoints where the active set
+ *  of programs changes, and renders one segment per breakpoint window. A
+ *  segment with one active program shows that program's color; with two
+ *  or more, a diagonal crosshatch alternates the colors so overlap is
+ *  visually unambiguous. */
+function ImpactBar({
+  cliffs,
+  zones,
+  maxGross,
+}: {
+  cliffs: CliffMark[];
+  zones: PitZone[];
+  maxGross: number;
+}) {
+  // Build a sorted list of unique breakpoints (zone starts and ends).
+  const breakpoints = Array.from(
+    new Set(zones.flatMap((z) => [z.x1, z.x2])),
+  ).sort((a, b) => a - b);
+
+  // For each [bp[i], bp[i+1]] window, the active set is every zone
+  // that contains the window (zone.x1 < bpEnd AND zone.x2 > bpStart).
+  const segments = breakpoints.slice(0, -1).map((start, i) => {
+    const end = breakpoints[i + 1];
+    const active = zones.filter((z) => z.x1 < end && z.x2 > start);
+    return { start, end, active };
+  });
+
+  // Match the chart's plot-area inset so the bar lines up with chart X.
+  const leftPad = 48 + 4;
+  const rightPad = 16 + 4;
+
+  const cliffById = new Map(cliffs.map((c) => [c.id, c]));
+
+  return (
+    <div style={{ marginTop: 8, paddingLeft: leftPad, paddingRight: rightPad }}>
+      <div
+        style={{
+          fontSize: rem(10),
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase',
+          color: T.inkMuted,
+          marginBottom: 4,
+        }}
+      >
+        Programs in pit
+      </div>
+      <div
+        style={{
+          position: 'relative',
+          height: 12,
+          background: T.bgAlt,
+          border: `1px solid ${T.border}`,
+        }}
+      >
+        {segments.map((seg, i) => {
+          if (seg.active.length === 0) return null;
+          const colors = seg.active
+            .map((z) => (z.cliffId ? cliffById.get(z.cliffId)?.color : null))
+            .filter((c): c is string => Boolean(c));
+          const left = `${(seg.start / maxGross) * 100}%`;
+          const width = `${((seg.end - seg.start) / maxGross) * 100}%`;
+          const labels = seg.active
+            .map((z) => (z.cliffId ? cliffById.get(z.cliffId)?.label : null))
+            .filter(Boolean)
+            .join(' + ');
+          return (
+            <div
+              key={i}
+              title={`${labels} · ${fmtK(seg.start)}–${fmtK(seg.end)}`}
+              style={{
+                position: 'absolute',
+                left,
+                width,
+                top: 0,
+                bottom: 0,
+                background: hatchedFill(colors),
+                opacity: 0.75,
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Build a CSS background that diagonally crosshatches the given colors.
+ *  Single color → solid fill. Two or more → repeating-linear-gradient
+ *  with each color taking an even slice. */
+function hatchedFill(colors: string[]): string {
+  if (colors.length === 0) return 'transparent';
+  if (colors.length === 1) return colors[0];
+  const stripeWidth = 6; // px per stripe
+  const total = stripeWidth * colors.length;
+  const stops = colors
+    .map((c, i) => {
+      const start = i * stripeWidth;
+      const end = (i + 1) * stripeWidth;
+      return `${c} ${start}px, ${c} ${end}px`;
+    })
+    .join(', ');
+  return `repeating-linear-gradient(45deg, ${stops}, ${colors[0]} ${total}px)`;
 }
 
 /** Per-program pit timeline. One labeled lane per cliff, with a colored

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -4089,6 +4089,7 @@ function CompoundConfigPanel({
     }));
   };
   const reset = () => setConfig(COMPOUND_DEFAULT_CONFIG);
+  const [collapsed, setCollapsed] = React.useState(false);
 
   return (
     <div
@@ -4103,7 +4104,7 @@ function CompoundConfigPanel({
         background: T.bgAlt,
         border: `1px dashed ${T.border}`,
         borderRadius: 4,
-        padding: 16,
+        padding: collapsed ? '8px 16px' : 16,
         marginBottom: 4,
         boxShadow: '0 4px 12px rgba(27, 24, 21, 0.08)',
       }}
@@ -4113,28 +4114,76 @@ function CompoundConfigPanel({
           display: 'flex',
           alignItems: 'baseline',
           justifyContent: 'space-between',
-          marginBottom: 12,
+          gap: 12,
+          marginBottom: collapsed ? 0 : 12,
         }}
       >
-        <div style={{ fontSize: rem(13), fontWeight: 600, color: T.ink }}>
-          Synthetic scenario config
-        </div>
         <button
           type="button"
-          onClick={reset}
+          onClick={() => setCollapsed((v) => !v)}
+          aria-expanded={!collapsed}
           style={{
             border: 'none',
             background: 'transparent',
-            color: T.inkMuted,
-            fontSize: rem(11),
-            textDecoration: 'underline',
-            cursor: 'pointer',
             padding: 0,
+            cursor: 'pointer',
+            fontFamily: fonts.body,
+            fontSize: rem(13),
+            fontWeight: 600,
+            color: T.ink,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
           }}
         >
-          Reset to defaults
+          <span
+            aria-hidden
+            style={{
+              display: 'inline-block',
+              width: 0,
+              height: 0,
+              borderLeft: '4px solid transparent',
+              borderRight: '4px solid transparent',
+              borderTop: `5px solid ${T.inkMuted}`,
+              transform: collapsed ? 'rotate(-90deg)' : 'rotate(0)',
+              transition: 'transform 0.15s',
+            }}
+          />
+          Synthetic scenario config
+          {collapsed && (
+            <span
+              style={{
+                fontWeight: 400,
+                color: T.inkMuted,
+                fontSize: rem(11),
+                marginLeft: 6,
+              }}
+            >
+              · {config.programs.length} program{config.programs.length === 1 ? '' : 's'} · slope{' '}
+              {config.slope.toFixed(2)}
+            </span>
+          )}
         </button>
+        {!collapsed && (
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: T.inkMuted,
+              fontSize: rem(11),
+              textDecoration: 'underline',
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          >
+            Reset to defaults
+          </button>
+        )}
       </div>
+      {!collapsed && (
+        <>
       <div
         style={{
           display: 'grid',
@@ -4270,6 +4319,8 @@ function CompoundConfigPanel({
           />
         </label>
       </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -4633,7 +4633,19 @@ function CompoundChartLayered({ config }: { config: CompoundConfig }) {
 
 function CompoundChartImpactBar({ config }: { config: CompoundConfig }) {
   const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
-  const impactZones = computePerCliffZones(points, cliffs);
+  // Per-program "impact zone" computed independently: each program's bar
+  // spans from its cliff to the income at which the curve would recover
+  // IF ONLY THIS PROGRAM HAD FIRED. Equals cliff.gross + drop/slope. Using
+  // computePerCliffZones (which uses the actual compound curve) instead
+  // would make every program's zone span almost the entire merged pit,
+  // since the curve doesn't reach a single program's pre-cliff peak until
+  // the other programs have also recovered.
+  const impactZones: PitZone[] = config.programs.map((p) => ({
+    cliffId: p.id,
+    color: p.color,
+    x1: p.gross,
+    x2: Math.min(maxGross, p.gross + p.drop / Math.max(0.01, config.slope)),
+  }));
   return (
     <CompoundFrame>
       <CompoundChartBase

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -4343,15 +4343,20 @@ function computePerCliffZones(
 ): PitZone[] {
   const zones: PitZone[] = [];
   for (const c of cliffs) {
-    let beforeIdx = 0;
+    // Find the last point STRICTLY before the cliff. The synthesized curve
+    // applies the drop at gross === cliff.gross, so the at-cliff point is
+    // already post-drop and would yield a trivially-met recovery. Use the
+    // pre-drop peak instead.
+    let beforeIdx = -1;
     for (let i = 0; i < points.length; i++) {
-      if (points[i].gross <= c.gross) beforeIdx = i;
+      if (points[i].gross < c.gross) beforeIdx = i;
       else break;
     }
+    if (beforeIdx < 0) continue;
     const beforeValue = points[beforeIdx].discretionary;
     let recoveryGross: number | null = null;
     for (let i = beforeIdx + 1; i < points.length; i++) {
-      if (points[i].discretionary >= beforeValue) {
+      if (points[i].gross > c.gross && points[i].discretionary >= beforeValue) {
         recoveryGross = points[i].gross;
         break;
       }

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -14,10 +14,31 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ReferenceDot,
+  ReferenceLine,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import { theme as T, fonts, rem } from '@/theme';
 import { Cite } from './ui';
 import type { Source } from '@/types';
 import type { ReviewKind } from '@/lib/sourceStatus';
+import { computeBudget } from '@/lib/budget';
+import { BENEFIT_IDS } from '@/lib/benefits';
+import { fpl } from '@/data/poverty';
+import {
+  MEDICAID_EXPANSION_LIMIT_FPL,
+  STATE_CHIP_LIMIT_FPL,
+  STATE_MEDICAID_POLICY,
+  snapIncomeLimitFpl,
+} from '@/data/benefits';
+import { getCityData } from '@/data/cities';
 
 /**
  * Each lab section gets an entry here. The sidebar reads this list to
@@ -86,6 +107,13 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
     status: 'decided',
     decidedAs: 'Primary / Reference / Commercial · green / slate-blue / gold',
     decidedNote: 'Shipped via PR #125. Picker preloads to these names; iterate to compare.',
+  },
+  {
+    id: 'cliffs',
+    nav: 'Cliff threshold annotations',
+    count: 5,
+    Component: SectionCliffAnnotations,
+    status: 'open',
   },
 ];
 
@@ -2668,5 +2696,732 @@ function ShareMockPostData() {
         </span>
       </div>
     </div>
+  );
+}
+
+// ── Section: cliff threshold annotations ─────────────────────────────────
+//
+// All five variations render the same income-sweep curve for one fixed
+// scenario (Columbus, OH · HoH · 2 kids · $40K), where SNAP, Medicaid, and
+// CHIP cutoffs cluster between $33K and $58K. Only the annotation
+// strategy differs. A second scenario (NYC · single · no kids · $30K)
+// renders below each variation to stress-test how each strategy handles
+// fewer cliffs spread further apart — to surface designs that look great
+// with three close cliffs but break down with one or two.
+
+function SectionCliffAnnotations() {
+  return (
+    <Section
+      heading="Cliff threshold annotations"
+      subhead="The Medicaid/SNAP/CHIP cutoffs cluster within $25K of each other for a Columbus household. The challenge: identify which vertical line is which program without overprinting labels, eating chart real estate, or burying the curve. Each variation is rendered against two scenarios to test robustness."
+    >
+      <Variation
+        title="V1 — Top labels with smart stagger (current production)"
+        description="Labels above each ReferenceLine; collisions auto-bump to a higher row. Reads top-down; eye has to travel from label to line."
+      >
+        <CliffStack Renderer={CliffChartTopLabelsStaggered} />
+      </Variation>
+      <Variation
+        title="V2 — Bottom-axis tags below the X axis"
+        description="Each cutoff gets a small color-coded tag below the axis at the right dollar amount. Chart stays clean above the curve; eye tracks dashed line down to its tag."
+      >
+        <CliffStack Renderer={CliffChartBottomAxisTags} />
+      </Variation>
+      <Variation
+        title="V3 — Inline labels riding the curve at the drop"
+        description="Each label sits next to the actual cliff drop on the curve, anchored to the data instead of floating overhead. Self-evidently which line maps to which program."
+      >
+        <CliffStack Renderer={CliffChartInlineAtDrop} />
+      </Variation>
+      <Variation
+        title="V4 — Numbered markers + legend"
+        description="Tiny ① ② ③ markers on the curve at each cliff; the legend below decodes them. Maximum chart cleanliness, minimum visual weight."
+      >
+        <CliffStack Renderer={CliffChartNumberedMarkers} />
+      </Variation>
+      <Variation
+        title="V5 — Color-banded eligibility regions"
+        description="Soft horizontal background bands shade the income ranges where each program is active. The transitions between bands ARE the cliffs — no separate markers needed. Reads as a stacked-area / state-of-the-world view."
+      >
+        <CliffStack Renderer={CliffChartColorBands} />
+      </Variation>
+    </Section>
+  );
+}
+
+/** Wraps any cliff-chart renderer in two stacked scenarios for comparison. */
+function CliffStack({ Renderer }: { Renderer: React.ComponentType<CliffScenarioProps> }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Renderer
+        scenarioLabel="Columbus, OH · HoH · 2 kids · $40K"
+        scenario={CLIFF_SCENARIO_CMH}
+      />
+      <Renderer
+        scenarioLabel="NYC · single · no kids · $30K"
+        scenario={CLIFF_SCENARIO_NYC}
+      />
+    </div>
+  );
+}
+
+interface CliffScenario {
+  city: string;
+  kids: number;
+  filing: import('@/types').FilingStatus;
+  lifestyle: import('@/types').Lifestyle;
+  hasPartner: boolean;
+  incomeA: number;
+  incomeB: number;
+}
+
+interface CliffScenarioProps {
+  scenarioLabel: string;
+  scenario: CliffScenario;
+}
+
+const CLIFF_SCENARIO_CMH: CliffScenario = {
+  city: 'cmh',
+  kids: 2,
+  filing: 'head',
+  lifestyle: 'moderate',
+  hasPartner: false,
+  incomeA: 40000,
+  incomeB: 0,
+};
+
+const CLIFF_SCENARIO_NYC: CliffScenario = {
+  city: 'nyc',
+  kids: 0,
+  filing: 'single',
+  lifestyle: 'moderate',
+  hasPartner: false,
+  incomeA: 30000,
+  incomeB: 0,
+};
+
+const CLIFF_COLORS: Record<string, string> = {
+  snap: T.warning,
+  medicaid: T.accent,
+  chip: T.aiAccent,
+};
+
+interface CliffPoint {
+  gross: number;
+  discretionary: number;
+}
+
+interface CliffMark {
+  id: string;
+  label: string;
+  shortLabel: string;
+  gross: number;
+  color: string;
+}
+
+/**
+ * Compute the income-sweep curve and cliff thresholds for a scenario. Mirrors
+ * the production CliffCurve component's math but returns plain data so each
+ * variation can render annotations differently without re-doing the work.
+ */
+function useCliffScenario(scenario: CliffScenario): {
+  points: CliffPoint[];
+  cliffs: CliffMark[];
+  maxGross: number;
+  currentGross: number;
+} {
+  return React.useMemo(() => {
+    const cityData = getCityData(scenario.city);
+    const householdSize = (scenario.hasPartner ? 2 : 1) + scenario.kids;
+    const allBenefits = new Set<string>(BENEFIT_IDS);
+    const currentGross = scenario.incomeA + scenario.incomeB;
+    const maxGross = Math.max(120_000, Math.ceil((currentGross * 1.5) / 1000) * 1000);
+    const stepSize = 500;
+
+    const points: CliffPoint[] = [];
+    for (let g = 0; g <= maxGross; g += stepSize) {
+      const sweepIncomeA = Math.max(0, g - scenario.incomeB);
+      const r = computeBudget({
+        incomeA: sweepIncomeA,
+        incomeB: scenario.incomeB,
+        hasPartner: scenario.hasPartner,
+        filing: scenario.filing,
+        city: scenario.city,
+        kids: scenario.kids,
+        lifestyle: scenario.lifestyle,
+        claimedBenefits: allBenefits,
+      });
+      points.push({ gross: g, discretionary: Math.round(r.annualDiscretionary) });
+    }
+
+    const fplBase = fpl(householdSize);
+    const cliffs: CliffMark[] = [];
+
+    cliffs.push({
+      id: 'snap',
+      label: `SNAP (${Math.round(snapIncomeLimitFpl(cityData.state) * 100)}% FPL)`,
+      shortLabel: 'SNAP',
+      gross: Math.round(fplBase * snapIncomeLimitFpl(cityData.state)),
+      color: CLIFF_COLORS.snap,
+    });
+
+    const policy = STATE_MEDICAID_POLICY[cityData.state];
+    if (policy.expanded) {
+      cliffs.push({
+        id: 'medicaid',
+        label: `Medicaid (138% FPL)`,
+        shortLabel: 'Medicaid',
+        gross: Math.round(fplBase * MEDICAID_EXPANSION_LIMIT_FPL),
+        color: CLIFF_COLORS.medicaid,
+      });
+    } else if (scenario.kids > 0 && policy.nonExpansionParentLimit !== undefined) {
+      const pct = Math.round(policy.nonExpansionParentLimit * 100);
+      cliffs.push({
+        id: 'medicaid',
+        label: `Medicaid parents (${pct}% FPL)`,
+        shortLabel: 'Medicaid',
+        gross: Math.round(fplBase * policy.nonExpansionParentLimit),
+        color: CLIFF_COLORS.medicaid,
+      });
+    }
+
+    if (scenario.kids > 0) {
+      const chipLimit = STATE_CHIP_LIMIT_FPL[cityData.state];
+      cliffs.push({
+        id: 'chip',
+        label: `CHIP (${Math.round(chipLimit * 100)}% FPL)`,
+        shortLabel: 'CHIP',
+        gross: Math.round(fplBase * chipLimit),
+        color: CLIFF_COLORS.chip,
+      });
+    }
+
+    return {
+      points,
+      cliffs: cliffs.filter((c) => c.gross > 0 && c.gross <= maxGross).sort((a, b) => a.gross - b.gross),
+      maxGross,
+      currentGross,
+    };
+  }, [scenario]);
+}
+
+function ScenarioFrame({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ background: T.surface, border: `1px solid ${T.border}`, padding: '12px 12px 8px' }}>
+      <div
+        style={{
+          fontSize: rem(10),
+          letterSpacing: '0.14em',
+          textTransform: 'uppercase',
+          color: T.inkMuted,
+          marginBottom: 6,
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const fmtK = (v: number) => (v === 0 ? '$0' : `$${Math.round(v / 1000)}K`);
+
+// V1 — Top labels with smart stagger (mirrors current production)
+function CliffChartTopLabelsStaggered({ scenarioLabel, scenario }: CliffScenarioProps) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+
+  // Stagger: each label takes the lowest row where it doesn't overlap any
+  // already-placed label at that row.
+  const minSpacing = maxGross * 0.1;
+  const placed: { gross: number; row: number }[] = [];
+  const annotated = cliffs.map((c) => {
+    let row = 0;
+    while (placed.some((p) => p.row === row && Math.abs(p.gross - c.gross) < minSpacing)) {
+      row += 1;
+    }
+    placed.push({ gross: c.gross, row });
+    return { ...c, row };
+  });
+  const maxRow = annotated.reduce((m, c) => Math.max(m, c.row), 0);
+
+  return (
+    <ScenarioFrame label={scenarioLabel}>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart
+          data={points}
+          margin={{ top: 16 + maxRow * 13, right: 16, left: 0, bottom: 8 }}
+        >
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {annotated.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              label={(props: { viewBox?: { x?: number; y?: number } }) => (
+                <text
+                  x={props.viewBox?.x ?? 0}
+                  y={(props.viewBox?.y ?? 0) - 4 - c.row * 13}
+                  fill={c.color}
+                  fontSize={10}
+                  textAnchor="middle"
+                >
+                  {c.shortLabel}
+                </text>
+              )}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+// V2 — Bottom-axis tags below the X axis
+function CliffChartBottomAxisTags({ scenarioLabel, scenario }: CliffScenarioProps) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+
+  return (
+    <ScenarioFrame label={scenarioLabel}>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={points} margin={{ top: 8, right: 16, left: 0, bottom: 36 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              label={(props: { viewBox?: { x?: number; y?: number; height?: number } }) => {
+                const x = props.viewBox?.x ?? 0;
+                const y = (props.viewBox?.y ?? 0) + (props.viewBox?.height ?? 0);
+                return (
+                  <g transform={`translate(${x}, ${y + 6})`}>
+                    <rect
+                      x={-32}
+                      y={0}
+                      width={64}
+                      height={16}
+                      fill={c.color}
+                      rx={2}
+                    />
+                    <text
+                      x={0}
+                      y={11}
+                      fill={T.bg}
+                      fontSize={10}
+                      textAnchor="middle"
+                      fontWeight={600}
+                    >
+                      {c.shortLabel}
+                    </text>
+                  </g>
+                );
+              }}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+// V3 — Inline labels at the drop
+function CliffChartInlineAtDrop({ scenarioLabel, scenario }: CliffScenarioProps) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+
+  // For each cliff, find the discretionary value just before the drop —
+  // that's where we anchor the label.
+  const annotated = cliffs.map((c) => {
+    let before = points[0];
+    for (const p of points) {
+      if (p.gross <= c.gross) before = p;
+      else break;
+    }
+    return { ...c, anchorY: before.discretionary };
+  });
+
+  return (
+    <ScenarioFrame label={scenarioLabel}>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={points} margin={{ top: 8, right: 70, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {annotated.map((c) => (
+            <ReferenceDot
+              key={c.id}
+              x={c.gross}
+              y={c.anchorY}
+              r={3}
+              fill={c.color}
+              stroke={T.bg}
+              strokeWidth={1.5}
+              ifOverflow="visible"
+              label={(props: { viewBox?: { cx?: number; cy?: number } }) => (
+                <g
+                  transform={`translate(${(props.viewBox?.cx ?? 0) + 8}, ${(props.viewBox?.cy ?? 0) - 2})`}
+                >
+                  <text fill={c.color} fontSize={10} fontWeight={600}>
+                    {c.shortLabel}
+                  </text>
+                </g>
+              )}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+// V4 — Numbered markers + legend
+function CliffChartNumberedMarkers({ scenarioLabel, scenario }: CliffScenarioProps) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+
+  const annotated = cliffs.map((c, i) => {
+    let before = points[0];
+    for (const p of points) {
+      if (p.gross <= c.gross) before = p;
+      else break;
+    }
+    return { ...c, anchorY: before.discretionary, num: i + 1 };
+  });
+
+  return (
+    <ScenarioFrame label={scenarioLabel}>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={points} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {annotated.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="2 4"
+              strokeOpacity={0.6}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          {annotated.map((c) => (
+            <ReferenceDot
+              key={c.id}
+              x={c.gross}
+              y={c.anchorY}
+              r={9}
+              fill={c.color}
+              stroke={T.bg}
+              strokeWidth={2}
+              ifOverflow="visible"
+              label={(props: { viewBox?: { cx?: number; cy?: number } }) => (
+                <text
+                  x={props.viewBox?.cx ?? 0}
+                  y={(props.viewBox?.cy ?? 0) + 3}
+                  fill={T.bg}
+                  fontSize={10}
+                  textAnchor="middle"
+                  fontWeight={700}
+                >
+                  {c.num}
+                </text>
+              )}
+            />
+          ))}
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 12,
+          fontSize: rem(11),
+          color: T.inkSoft,
+          marginTop: 6,
+        }}
+      >
+        {annotated.map((c) => (
+          <span key={c.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 16,
+                height: 16,
+                borderRadius: '50%',
+                background: c.color,
+                color: T.bg,
+                textAlign: 'center',
+                lineHeight: '16px',
+                fontSize: rem(10),
+                fontWeight: 700,
+              }}
+            >
+              {c.num}
+            </span>
+            {c.label}
+          </span>
+        ))}
+      </div>
+    </ScenarioFrame>
+  );
+}
+
+// V5 — Color-banded eligibility regions
+function CliffChartColorBands({ scenarioLabel, scenario }: CliffScenarioProps) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+
+  // Build sorted ascending cutoff list; each "region" is the interval
+  // between two consecutive cutoffs (or 0 / maxGross at the bookends).
+  // Each region's tint shows which programs are still active in it.
+  const sortedCliffs = [...cliffs].sort((a, b) => a.gross - b.gross);
+  interface Region {
+    x1: number;
+    x2: number;
+    activeIds: string[];
+  }
+  const regions: Region[] = [];
+  let prev = 0;
+  // At income = 0, every program is active. As we cross each cutoff (in
+  // ascending order), the program at that cutoff drops out.
+  let active = sortedCliffs.map((c) => c.id);
+  for (const c of sortedCliffs) {
+    regions.push({ x1: prev, x2: c.gross, activeIds: [...active] });
+    active = active.filter((id) => id !== c.id);
+    prev = c.gross;
+  }
+  regions.push({ x1: prev, x2: maxGross, activeIds: [] });
+
+  return (
+    <ScenarioFrame label={scenarioLabel}>
+      <ResponsiveContainer width="100%" height={220}>
+        <LineChart data={points} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          {regions.map((r, i) => {
+            // Tint: blend region color from the most "valuable" remaining
+            // program (medicaid > chip > snap, by editorial weight). Using
+            // a soft 8% opacity so it whispers rather than shouts.
+            const dominant = r.activeIds.includes('medicaid')
+              ? CLIFF_COLORS.medicaid
+              : r.activeIds.includes('chip')
+                ? CLIFF_COLORS.chip
+                : r.activeIds.includes('snap')
+                  ? CLIFF_COLORS.snap
+                  : 'transparent';
+            return (
+              <ReferenceArea
+                key={i}
+                x1={r.x1}
+                x2={r.x2}
+                fill={dominant}
+                fillOpacity={dominant === 'transparent' ? 0 : 0.08}
+                stroke="none"
+              />
+            );
+          })}
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ??
+              points[0].discretionary
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 12,
+          fontSize: rem(11),
+          color: T.inkSoft,
+          marginTop: 6,
+        }}
+      >
+        {sortedCliffs.map((c) => (
+          <span key={c.id} style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 12,
+                height: 12,
+                background: c.color,
+                opacity: 0.5,
+              }}
+            />
+            {c.label} ends at {fmtK(c.gross)}
+          </span>
+        ))}
+      </div>
+    </ScenarioFrame>
   );
 }

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -4095,7 +4095,7 @@ function CompoundConfigPanel({
     }));
   };
   const reset = () => setConfig(COMPOUND_DEFAULT_CONFIG);
-  const [collapsed, setCollapsed] = React.useState(false);
+  const [collapsed, setCollapsed] = React.useState(true);
 
   return (
     <div

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -126,7 +126,7 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
   {
     id: 'compound',
     nav: 'Compound pit attribution',
-    count: 4,
+    count: 5,
     Component: SectionCompoundPits,
     status: 'open',
   },
@@ -4051,6 +4051,12 @@ function SectionCompoundPits() {
       >
         <CompoundChartLayered config={config} />
       </Variation>
+      <Variation
+        title="V5 — Uniform warning color (no attribution at all)"
+        description="Every pit zone shaded the same warning orange regardless of which program caused it. Cleanest possible read; sacrifices attribution entirely but never lies about which program is responsible since it never claims one."
+      >
+        <CompoundChartUniformColor config={config} />
+      </Variation>
     </Section>
   );
 }
@@ -4376,6 +4382,25 @@ function CompoundChartSingleColor({ config }: { config: CompoundConfig }) {
         points={points}
         cliffs={cliffs}
         zones={pitZones}
+        maxGross={maxGross}
+        currentGross={currentGross}
+      />
+    </CompoundFrame>
+  );
+}
+
+function CompoundChartUniformColor({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
+  // Strip per-program color attribution — every zone painted with the
+  // same warning hue. CompoundChartBase falls back to T.warning when a
+  // zone's color is undefined.
+  const uniformZones: PitZone[] = pitZones.map((z) => ({ ...z, color: undefined }));
+  return (
+    <CompoundFrame>
+      <CompoundChartBase
+        points={points}
+        cliffs={cliffs}
+        zones={uniformZones}
         maxGross={maxGross}
         currentGross={currentGross}
       />

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -128,7 +128,10 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
     nav: 'Compound pit attribution',
     count: 6,
     Component: SectionCompoundPits,
-    status: 'open',
+    status: 'decided',
+    decidedAs: 'V5 — uniform warning color, no per-program attribution',
+    decidedNote:
+      'Attribution-by-color was always going to lie when multiple cliffs contributed to a merged pit. V5 says "something is wrong here" without overclaiming which program. Per-cliff caption below the chart already names the responsible programs in plain language.',
   },
 ];
 
@@ -4052,6 +4055,7 @@ function SectionCompoundPits() {
         <CompoundChartLayered config={config} />
       </Variation>
       <Variation
+        decided
         title="V5 — Uniform warning color (no attribution at all)"
         description="Every pit zone shaded the same warning orange regardless of which program caused it. Cleanest possible read; sacrifices attribution entirely but never lies about which program is responsible since it never claims one."
       >

--- a/src/components/DesignLab.tsx
+++ b/src/components/DesignLab.tsx
@@ -126,7 +126,7 @@ const LAB_SECTIONS: ReadonlyArray<LabSection> = [
   {
     id: 'compound',
     nav: 'Compound pit attribution',
-    count: 5,
+    count: 6,
     Component: SectionCompoundPits,
     status: 'open',
   },
@@ -4057,6 +4057,12 @@ function SectionCompoundPits() {
       >
         <CompoundChartUniformColor config={config} />
       </Variation>
+      <Variation
+        title="V6 — Ghost line + uniform warning shading"
+        description="V3 and V5 combined. Soft warning tint behind every pit (says 'look here, something's wrong'); faded best-so-far line above the actual curve (shows how much money the household is leaving on the table at every income). No attribution decisions, depth is automatic."
+      >
+        <CompoundChartGhostShaded config={config} />
+      </Variation>
     </Section>
   );
 }
@@ -4460,6 +4466,86 @@ function CompoundChartGhost({ config }: { config: CompoundConfig }) {
       <ResponsiveContainer width="100%" height={260}>
         <LineChart data={ghostPoints} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
           <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={48}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.6}
+            />
+          ))}
+          <Line
+            type="stepAfter"
+            dataKey="ghost"
+            stroke={T.warning}
+            strokeWidth={1.5}
+            strokeDasharray="4 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="actual"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={ghostPoints.find((p) => p.gross >= currentGross)?.actual ?? ghostPoints[0].actual}
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </CompoundFrame>
+  );
+}
+
+function CompoundChartGhostShaded({ config }: { config: CompoundConfig }) {
+  const { points, cliffs, pitZones, maxGross, currentGross } = useCompoundDemoData(config);
+  const ghostPoints = (() => {
+    let runningMax = -Infinity;
+    return points.map((p) => {
+      runningMax = Math.max(runningMax, p.discretionary);
+      return { gross: p.gross, ghost: runningMax, actual: p.discretionary };
+    });
+  })();
+  return (
+    <CompoundFrame>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={ghostPoints} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          {pitZones.map((z, i) => (
+            <ReferenceArea
+              key={i}
+              x1={z.x1}
+              x2={z.x2}
+              fill={T.warning}
+              fillOpacity={0.1}
+              stroke="none"
+            />
+          ))}
           <XAxis
             dataKey="gross"
             type="number"

--- a/src/components/PageNav.tsx
+++ b/src/components/PageNav.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react';
+import { theme as T, fonts, rem } from '@/theme';
+
+export interface PageNavSection {
+  id: string;
+  label: string;
+}
+
+/**
+ * Fixed-position section navigator. Sits on the right edge of the viewport
+ * and offers click-to-scroll for each section on the page. Highlights the
+ * section currently in view via IntersectionObserver. Hidden on narrow
+ * viewports (where the page is already a vertical stack and a side rail
+ * would steal horizontal room from the data-dense charts).
+ *
+ * Sections need matching `id` attributes on the `<section>` (or any) element
+ * in the page itself; this component does no DOM mutation, just smooth-
+ * scrolls to the anchor on click.
+ */
+export function PageNav({ sections }: { sections: readonly PageNavSection[] }) {
+  const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? '');
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return;
+    const elements = sections
+      .map((s) => document.getElementById(s.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    // Pick the section whose top is closest to the viewport's "reading line"
+    // (~25% down from the top). Plain "topmost intersecting" picks the wrong
+    // section when two are partially visible at once.
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Track every observed section's current top relative to the
+        // viewport, then choose the one closest to 0 from above.
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible.length > 0) {
+          setActiveId(visible[0].target.id);
+        }
+      },
+      { rootMargin: '-25% 0px -55% 0px', threshold: 0 },
+    );
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [sections]);
+
+  const onClick = (e: React.MouseEvent, id: string) => {
+    e.preventDefault();
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    // Update history so the back button returns to the previous section.
+    if (typeof window !== 'undefined') {
+      const hashlessUrl = window.location.pathname + window.location.search;
+      window.history.replaceState(null, '', `${hashlessUrl}${window.location.hash}`);
+    }
+  };
+
+  return (
+    <nav
+      aria-label="Page sections"
+      style={{
+        position: 'fixed',
+        top: '50%',
+        right: 16,
+        transform: 'translateY(-50%)',
+        zIndex: 5,
+        // Hidden by default; the media query below shows it on wide viewports
+        // where there's room for a side rail without crowding the main column.
+        display: 'none',
+      }}
+      className="page-nav"
+    >
+      {/* Inline style tag is the lightest way to add a media query without
+          pulling in CSS-in-JS infra; the rest of the app uses inline styles. */}
+      <style>{`
+        @media (min-width: 1400px) {
+          .page-nav { display: block !important; }
+        }
+      `}</style>
+      <ul
+        style={{
+          listStyle: 'none',
+          margin: 0,
+          padding: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          fontFamily: fonts.body,
+          fontSize: rem(11),
+        }}
+      >
+        {sections.map((s) => {
+          const isActive = activeId === s.id;
+          return (
+            <li key={s.id}>
+              <a
+                href={`#${s.id}`}
+                onClick={(e) => onClick(e, s.id)}
+                aria-current={isActive ? 'true' : undefined}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '6px 0 6px 12px',
+                  borderLeft: `2px solid ${isActive ? T.accent : 'transparent'}`,
+                  color: isActive ? T.ink : T.inkMuted,
+                  textDecoration: 'none',
+                  fontWeight: isActive ? 600 : 400,
+                  letterSpacing: '0.02em',
+                  whiteSpace: 'nowrap',
+                  transition: 'color 0.15s, border-color 0.15s',
+                }}
+              >
+                <span
+                  aria-hidden
+                  style={{
+                    display: 'inline-block',
+                    width: 4,
+                    height: 4,
+                    borderRadius: '50%',
+                    background: isActive ? T.accent : T.border,
+                  }}
+                />
+                {s.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/PitWarning.tsx
+++ b/src/components/PitWarning.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+import type { FilingStatus, Lifestyle } from '@/types';
+import { theme as T, fonts, rem } from '@/theme';
+import { fmt } from '@/lib/format';
+import { findIncomePit } from '@/lib/cliffs';
+
+const BENEFIT_NAMES: Record<string, string> = {
+  snap: 'SNAP',
+  medicaid: 'Medicaid',
+  chip: 'CHIP',
+};
+
+/**
+ * Surfaces the cliff-trap directly: when the household's *current* income
+ * leaves them with less annual discretionary income than they'd have at
+ * some lower income (because of benefit cutoffs they've crossed). Renders
+ * nothing when no pit exists.
+ */
+export function PitWarning({
+  city,
+  kids,
+  filing,
+  lifestyle,
+  hasPartner,
+  incomeA,
+  incomeB,
+}: {
+  city: string;
+  kids: number;
+  filing: FilingStatus;
+  lifestyle: Lifestyle;
+  hasPartner: boolean;
+  incomeA: number;
+  incomeB: number;
+}) {
+  const pit = useMemo(
+    () => findIncomePit({ city, kids, filing, lifestyle, hasPartner, incomeA, incomeB }),
+    [city, kids, filing, lifestyle, hasPartner, incomeA, incomeB],
+  );
+
+  if (!pit) return null;
+
+  const programs = pit.programsGained.map((p) => BENEFIT_NAMES[p] ?? p).join(' + ');
+
+  return (
+    <div
+      role="status"
+      style={{
+        background: T.surface,
+        border: `1px solid ${T.warning}`,
+        borderLeft: `4px solid ${T.warning}`,
+        padding: '14px 18px',
+        marginBottom: 24,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <div
+        style={{
+          fontSize: rem(11),
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: T.warning,
+          fontWeight: 600,
+        }}
+      >
+        ⚠ You're in a benefits cliff
+      </div>
+      <div style={{ fontFamily: fonts.body, fontSize: rem(14), color: T.ink, lineHeight: 1.5 }}>
+        At {fmt(incomeA + incomeB)}/yr, this household is left with{' '}
+        <strong>{fmt(pit.currentDiscretionary)}/yr</strong> after taxes and expenses. At{' '}
+        <strong>{fmt(pit.optimalGross)}/yr</strong> — earning roughly{' '}
+        {fmt(incomeA + incomeB - pit.optimalGross)} less — they'd have{' '}
+        <strong>{fmt(pit.optimalDiscretionary)}/yr</strong>, a gain of{' '}
+        <strong style={{ color: T.warning }}>{fmt(pit.delta)}/yr</strong>.
+      </div>
+      {programs && (
+        <div style={{ fontFamily: fonts.body, fontSize: rem(13), color: T.inkSoft }}>
+          The lower income would qualify them for{' '}
+          <strong style={{ color: T.ink }}>{programs}</strong>, more than offsetting the lost
+          paycheck.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -225,6 +225,14 @@ export const ROADMAP: readonly RoadmapItem[] = [
       'The Atlas computes eligibility for SNAP, Medicaid, and CHIP, but plenty of programs sit adjacent to the same life situations and never surface. A laid-off worker should hear about unemployment insurance the moment they tell us their income dropped. A new parent should hear about WIC. A renter behind on utilities should hear about LIHEAP. A household near tax-filing time should hear about VITA / Free File. A disabled adult should hear about SSDI / SSI. Two layers: (1) a contextual "you may also want to look into…" callout that triggers off household state changes — state-specific links to the right portal; and (2) the same guided-application treatment #126 plans for SNAP / Medicaid / CHIP, applied here too — application form, documents needed, portal URL for the user\'s state, and any agency-run pre-check we can surface — so "you might qualify" becomes "here\'s the next step," not just a hyperlink and a shrug.',
     status: 'planned',
   },
+  {
+    id: 128,
+    title: 'Implicit marginal tax rate view',
+    category: 'Benefits & safety net',
+    status: 'planned',
+    summary:
+      'Plot the *slope* of the discretionary curve as its own line — the implicit marginal tax rate the household actually faces, including benefit phase-outs and refundable-credit reductions, not just income-tax brackets. Each cliff would show as a brief spike to ≥100% (every $1 earned costs more than $1) followed by an elevated plateau through the recovery zone. Makes legible why a $4K Medicaid loss takes an $11K raise to climb out of: the marginal keep-rate is much worse than the headline tax bracket suggests once EITC/SNAP phase-downs and untaxed-benefit replacement costs stack up. Companion to the existing cliff curve.',
+  },
 ];
 
 /**

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -233,6 +233,14 @@ export const ROADMAP: readonly RoadmapItem[] = [
     summary:
       'Plot the *slope* of the discretionary curve as its own line — the implicit marginal tax rate the household actually faces, including benefit phase-outs and refundable-credit reductions, not just income-tax brackets. Each cliff would show as a brief spike to ≥100% (every $1 earned costs more than $1) followed by an elevated plateau through the recovery zone. Makes legible why a $4K Medicaid loss takes an $11K raise to climb out of: the marginal keep-rate is much worse than the headline tax bracket suggests once EITC/SNAP phase-downs and untaxed-benefit replacement costs stack up. Companion to the existing cliff curve.',
   },
+  {
+    id: 129,
+    title: 'Asymmetric Medicaid value vs. post-cliff cost',
+    category: 'Benefits & safety net',
+    status: 'planned',
+    summary:
+      "Today the model conflates two different things into a single number (cityData.healthFamily, sourced from KFF's Employer Health Benefits Survey): (a) the dollar VALUE of Medicaid/CHIP coverage when a household qualifies, and (b) the household's healthcare EXPENSE when they don't. Setting these equal makes the cliff drop on the Discretionary line equal the cliff drop on the Take-home + benefits line — they're the same magnitude, just measured from different angles. In reality the two diverge: Medicaid is meaningfully better than typical employer coverage ($0 deductible, $0 copays, broader pediatric benefits) so its real actuarial value is HIGHER than a worker would pay for an equivalent plan; AND a household losing Medicaid often lands on an ACA marketplace plan that costs MORE than the modeled employer premium. Splitting these into separate values (medicaidValue, chipValue, postCliffCost) would make the Discretionary cliff legitimately differ in size from the Take-home + benefits cliff — capturing a real economic asymmetry. Likely sources: ACA marketplace median premium data (Healthcare.gov/state exchanges), MEPS for actuarial value of Medicaid, KFF for employer comparisons.",
+  },
 ];
 
 /**

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -113,7 +113,7 @@ export const ROADMAP: readonly RoadmapItem[] = [
     category: 'Benefits & safety net',
     status: 'planned',
     summary:
-      'Surface alternate Medicaid tracks the model omits — SSI-linked, aged (65+), and pregnancy (often 200%+ FPL even in non-expansion states). Plus state waiver programs. (The 138% FPL Medicaid cliff is now visualized in the income-sweep curve.)',
+      'Surface alternate Medicaid tracks the model omits — SSI-linked, aged (65+), and pregnancy (often 200%+ FPL even in non-expansion states). Plus state waiver programs. Also: state-charged CHIP premiums for families above ~150% FPL (varies by state — TX ~$35–50/mo, PA tiered up to ~$56/mo/child, FL ~$15–20/mo, etc.). Today CHIP value = full kids\' share of the family premium with no offset for the small monthly premium real higher-income families actually pay; small but real overstatement near the upper eligibility bands. (The 138% FPL Medicaid cliff is now visualized in the income-sweep curve.)',
   },
   {
     id: 11,

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -113,7 +113,7 @@ export const ROADMAP: readonly RoadmapItem[] = [
     category: 'Benefits & safety net',
     status: 'planned',
     summary:
-      'Surface alternate Medicaid tracks the model omits — SSI-linked, aged (65+), and pregnancy (often 200%+ FPL even in non-expansion states). Plus state waiver programs. Also: state-charged CHIP premiums for families above ~150% FPL (varies by state — TX ~$35–50/mo, PA tiered up to ~$56/mo/child, FL ~$15–20/mo, etc.). Today CHIP value = full kids\' share of the family premium with no offset for the small monthly premium real higher-income families actually pay; small but real overstatement near the upper eligibility bands. (The 138% FPL Medicaid cliff is now visualized in the income-sweep curve.)',
+      "Surface alternate Medicaid tracks the model omits — SSI-linked, aged (65+), and pregnancy (often 200%+ FPL even in non-expansion states). Plus state waiver programs. Also: state-charged CHIP premiums for families above ~150% FPL (varies by state — TX ~$35–50/mo, PA tiered up to ~$56/mo/child, FL ~$15–20/mo, etc.). Today CHIP value = full kids' share of the family premium with no offset for the small monthly premium real higher-income families actually pay; small but real overstatement near the upper eligibility bands. (The 138% FPL Medicaid cliff is now visualized in the income-sweep curve.)",
   },
   {
     id: 11,

--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -105,7 +105,7 @@ export const ROADMAP: readonly RoadmapItem[] = [
     category: 'Benefits & safety net',
     status: 'planned',
     summary:
-      'Add shelter and childcare deductions to the SNAP net-income formula — real SNAP subtracts both before applying the 30% multiplier, meaningful in high-rent metros. Plus a calculation breakdown UI and a cliff visualization.',
+      'Add shelter and childcare deductions to the SNAP net-income formula — real SNAP subtracts both before applying the 30% multiplier, meaningful in high-rent metros. Plus a calculation breakdown UI. (The income-sweep cliff visualization shipped separately.)',
   },
   {
     id: 10,
@@ -113,7 +113,7 @@ export const ROADMAP: readonly RoadmapItem[] = [
     category: 'Benefits & safety net',
     status: 'planned',
     summary:
-      'Surface alternate Medicaid tracks the model omits — SSI-linked, aged (65+), and pregnancy (often 200%+ FPL even in non-expansion states). Plus state waiver programs and a visualization of the Medicaid cliff at 138% FPL.',
+      'Surface alternate Medicaid tracks the model omits — SSI-linked, aged (65+), and pregnancy (often 200%+ FPL even in non-expansion states). Plus state waiver programs. (The 138% FPL Medicaid cliff is now visualized in the income-sweep curve.)',
   },
   {
     id: 11,

--- a/src/lib/benefits.ts
+++ b/src/lib/benefits.ts
@@ -138,6 +138,28 @@ export function checkSnap({
  *
  * Children's Medicaid is broader; we route kids through CHIP as the
  * separate program, which subsumes Medicaid-for-kids in this model.
+ *
+ * ── How we compute the dollar VALUE of Medicaid ──
+ * `monthlyBenefit = monthlyHealthcareCost`, where `monthlyHealthcareCost`
+ * is the household's `cityData.healthFamily` (or healthSingle) figure
+ * sourced from KFF's Employer Health Benefits Survey — the worker's share
+ * of an employer-sponsored family premium. The model treats Medicaid as
+ * worth exactly what employer-sponsored coverage would cost the worker,
+ * which is a simplification with two real-world limitations:
+ *
+ *  (a) Medicaid is genuinely better than typical employer coverage —
+ *      $0 deductible, $0 copays, often broader dental/vision for kids —
+ *      so its actuarial value is higher than what a worker would pay
+ *      for an equivalent private plan.
+ *  (b) Conversely, a household losing Medicaid often lands on an ACA
+ *      marketplace plan that costs MORE than the modeled employer
+ *      premium (different premium, plus deductibles + out-of-pocket
+ *      max). So the post-cliff expense undercounts real-world cost.
+ *
+ * The symmetry — Medicaid value == post-cliff healthcare expense —
+ * means cliff drops on the Discretionary line equal cliff drops on the
+ * Take-home + benefits line. A more honest model would split these.
+ * See roadmap: "Asymmetric Medicaid value vs. post-cliff cost".
  */
 export function checkMedicaid({
   grossIncome,
@@ -194,9 +216,14 @@ export function checkMedicaid({
 
 /**
  * CHIP eligibility. Per-state income limit (typically 200%–400% FPL).
- * Only relevant when there are children in the household. Benefit value
- * is the kids' share of the family premium — the marginal cost of adding
- * children to an adult-only plan:
+ * Only relevant when there are children in the household.
+ *
+ * ── How we compute the dollar VALUE of CHIP ──
+ * Same KFF Employer Health Benefits Survey lineage as Medicaid: the
+ * `monthlyHealthcareCost` and `monthlyHealthcareSingle` are from
+ * `cityData.healthFamily` and `cityData.healthSingle` respectively.
+ * CHIP value is the kids' marginal share of the family premium — the
+ * cost of adding children to an adult-only plan:
  *
  *   1 adult + kids   →  family premium − single-coverage premium
  *   2 adults + kids  →  family premium − (2 × single-coverage premium)
@@ -205,6 +232,14 @@ export function checkMedicaid({
  *
  * Real CHIP often charges small premiums above ~150% FPL (varies by state);
  * we treat coverage as fully replacing the kids' share for simplicity.
+ *
+ * Same caveat as Medicaid: by treating CHIP value as exactly the kids'
+ * employer-premium share, we assume the post-CHIP-cliff household pays
+ * exactly that amount to add kids to a private plan. The true value of
+ * CHIP coverage (low/no copays, broad pediatric coverage) is likely
+ * higher; the true post-cliff cost depends on whether the household
+ * has employer coverage available or has to use the marketplace. See
+ * roadmap: "Asymmetric Medicaid value vs. post-cliff cost".
  */
 export function checkChip({
   grossIncome,

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -127,7 +127,9 @@ describe('computeBudget — benefits integration', () => {
  */
 describe('computeBudget — pinned regressions', () => {
   it('low-income HoH with 2 kids in Columbus: refundable credits drive negative federal tax', () => {
-    const r = computeBudget(input({ incomeA: 25_000, filing: 'head', city: 'cmh', kids: 2, lifestyle: 'modest' }));
+    const r = computeBudget(
+      input({ incomeA: 25_000, filing: 'head', city: 'cmh', kids: 2, lifestyle: 'modest' }),
+    );
     expect(Math.round(r.federalTax)).toBe(-10_422); // CTC $4,000 + EITC $7,022, raw fed ~$600
     expect(Math.round(r.ctc)).toBe(4_000);
     expect(Math.round(r.eitc)).toBe(7_022);
@@ -137,7 +139,9 @@ describe('computeBudget — pinned regressions', () => {
   });
 
   it('median single in Columbus: standard middle-class profile', () => {
-    const r = computeBudget(input({ incomeA: 75_000, filing: 'single', city: 'cmh', kids: 0, lifestyle: 'moderate' }));
+    const r = computeBudget(
+      input({ incomeA: 75_000, filing: 'single', city: 'cmh', kids: 0, lifestyle: 'moderate' }),
+    );
     expect(Math.round(r.federalTax)).toBe(7_670);
     expect(Math.round(r.stateTax)).toBe(1_346);
     expect(Math.round(r.fica)).toBe(5_738);
@@ -146,14 +150,21 @@ describe('computeBudget — pinned regressions', () => {
   });
 
   it('dual-earner $200K+$200K married in NYC with 2 kids: per-person FICA + city tax', () => {
-    const r = computeBudget(input({
-      incomeA: 200_000, incomeB: 200_000, hasPartner: true,
-      filing: 'married', city: 'nyc', kids: 2, lifestyle: 'comfortable',
-    }));
+    const r = computeBudget(
+      input({
+        incomeA: 200_000,
+        incomeB: 200_000,
+        hasPartner: true,
+        filing: 'married',
+        city: 'nyc',
+        kids: 2,
+        lifestyle: 'comfortable',
+      }),
+    );
     expect(Math.round(r.federalTax)).toBe(69_468);
     expect(Math.round(r.stateTax)).toBe(22_413);
     expect(Math.round(r.localTax)).toBe(15_200); // NYC local tax
-    expect(Math.round(r.fica)).toBe(28_678);     // two SS wage bases
+    expect(Math.round(r.fica)).toBe(28_678); // two SS wage bases
     expect(Math.round(r.totalTaxes)).toBe(135_759);
   });
 });

--- a/src/lib/budget.test.ts
+++ b/src/lib/budget.test.ts
@@ -119,3 +119,41 @@ describe('computeBudget — benefits integration', () => {
     expect(r.totalBenefits).toBe(0);
   });
 });
+
+/**
+ * Pinned exact-value regressions across the income spectrum. Update these
+ * deliberately when tax brackets, credit amounts, or cost-of-living tables
+ * change for a new year — the diff documents what moved and why.
+ */
+describe('computeBudget — pinned regressions', () => {
+  it('low-income HoH with 2 kids in Columbus: refundable credits drive negative federal tax', () => {
+    const r = computeBudget(input({ incomeA: 25_000, filing: 'head', city: 'cmh', kids: 2, lifestyle: 'modest' }));
+    expect(Math.round(r.federalTax)).toBe(-10_422); // CTC $4,000 + EITC $7,022, raw fed ~$600
+    expect(Math.round(r.ctc)).toBe(4_000);
+    expect(Math.round(r.eitc)).toBe(7_022);
+    expect(Math.round(r.fica)).toBe(1_913);
+    expect(Math.round(r.totalTaxes)).toBe(-7_884);
+    expect(Math.round(r.netIncome)).toBe(32_884);
+  });
+
+  it('median single in Columbus: standard middle-class profile', () => {
+    const r = computeBudget(input({ incomeA: 75_000, filing: 'single', city: 'cmh', kids: 0, lifestyle: 'moderate' }));
+    expect(Math.round(r.federalTax)).toBe(7_670);
+    expect(Math.round(r.stateTax)).toBe(1_346);
+    expect(Math.round(r.fica)).toBe(5_738);
+    expect(Math.round(r.totalTaxes)).toBe(16_629);
+    expect(Math.round(r.netIncome)).toBe(58_371);
+  });
+
+  it('dual-earner $200K+$200K married in NYC with 2 kids: per-person FICA + city tax', () => {
+    const r = computeBudget(input({
+      incomeA: 200_000, incomeB: 200_000, hasPartner: true,
+      filing: 'married', city: 'nyc', kids: 2, lifestyle: 'comfortable',
+    }));
+    expect(Math.round(r.federalTax)).toBe(69_468);
+    expect(Math.round(r.stateTax)).toBe(22_413);
+    expect(Math.round(r.localTax)).toBe(15_200); // NYC local tax
+    expect(Math.round(r.fica)).toBe(28_678);     // two SS wage bases
+    expect(Math.round(r.totalTaxes)).toBe(135_759);
+  });
+});

--- a/src/lib/cliffs.ts
+++ b/src/lib/cliffs.ts
@@ -28,7 +28,13 @@ export function computePitZones<P extends { gross: number }>(
   cliffs: readonly { id: string; gross: number; color: string }[],
 ): PitZone[] {
   const sortedCliffs = [...cliffs].sort((a, b) => b.gross - a.gross); // desc
-  const findCause = (zoneStart: number) => sortedCliffs.find((c) => c.gross < zoneStart);
+  // Use <= because a synthesized curve can open a pit at exactly the
+  // cliff's gross (the drop is applied at g === cliff.gross). For real
+  // computed curves the zone opens at the next swept point past the
+  // cliff, so the strict-< relation also matches via the same lookup —
+  // <= covers both cases. Without this, attribution silently falls back
+  // to a default color and the program's accent never propagates.
+  const findCause = (zoneStart: number) => sortedCliffs.find((c) => c.gross <= zoneStart);
 
   const zones: PitZone[] = [];
   let runningMax = -Infinity;

--- a/src/lib/cliffs.ts
+++ b/src/lib/cliffs.ts
@@ -3,6 +3,68 @@ import { computeBudget } from '@/lib/budget';
 import { BENEFIT_IDS, checkBenefit, type BenefitId } from '@/lib/benefits';
 
 /**
+ * Compute "pit zones" along an income sweep: contiguous income ranges where
+ * the household ends up with less of `metricKey` than they would have at
+ * some lower income — i.e. crossing a benefit cutoff cost more than the
+ * raise was worth.
+ *
+ * Each zone is attributed to the cliff that caused it (the highest-gross
+ * cliff at or below the zone's start) so the UI can color-match zones to
+ * the program lost. If no cliff matches, the zone is returned without a
+ * color so the caller can apply a fallback.
+ */
+export interface PitZone {
+  x1: number;
+  x2: number;
+  /** Color of the cliff that triggered this zone, if attributable. */
+  color?: string;
+  /** Id of the cliff that triggered this zone, if attributable. */
+  cliffId?: string;
+}
+
+export function computePitZones<P extends { gross: number }>(
+  points: readonly P[],
+  metricKey: keyof P,
+  cliffs: readonly { id: string; gross: number; color: string }[],
+): PitZone[] {
+  const sortedCliffs = [...cliffs].sort((a, b) => b.gross - a.gross); // desc
+  const findCause = (zoneStart: number) => sortedCliffs.find((c) => c.gross < zoneStart);
+
+  const zones: PitZone[] = [];
+  let runningMax = -Infinity;
+  let currentZoneStart: number | null = null;
+
+  for (let i = 0; i < points.length; i++) {
+    const v = points[i][metricKey] as unknown as number;
+    if (v < runningMax) {
+      if (currentZoneStart === null) currentZoneStart = points[i].gross;
+    } else {
+      if (currentZoneStart !== null) {
+        const cause = findCause(currentZoneStart);
+        zones.push({
+          x1: currentZoneStart,
+          x2: points[i].gross,
+          color: cause?.color,
+          cliffId: cause?.id,
+        });
+        currentZoneStart = null;
+      }
+      runningMax = v;
+    }
+  }
+  if (currentZoneStart !== null && points.length > 0) {
+    const cause = findCause(currentZoneStart);
+    zones.push({
+      x1: currentZoneStart,
+      x2: points[points.length - 1].gross,
+      color: cause?.color,
+      cliffId: cause?.id,
+    });
+  }
+  return zones;
+}
+
+/**
  * "Pit" detection: at the current scenario, is there an income *below* the
  * current one where the household would end up with *more* annual
  * discretionary income? That happens when raising income across a benefit

--- a/src/lib/cliffs.ts
+++ b/src/lib/cliffs.ts
@@ -1,0 +1,102 @@
+import type { BudgetInput } from '@/types';
+import { computeBudget } from '@/lib/budget';
+import { BENEFIT_IDS, checkBenefit, type BenefitId } from '@/lib/benefits';
+
+/**
+ * "Pit" detection: at the current scenario, is there an income *below* the
+ * current one where the household would end up with *more* annual
+ * discretionary income? That happens when raising income across a benefit
+ * eligibility cutoff costs more in lost benefits than it gained in
+ * paycheck — the cliff trap.
+ *
+ * The sweep auto-claims every benefit at every income point so we measure
+ * the genuinely optimal outcome at each income level (not whatever the user
+ * happens to have toggled). If the user is currently below all cliffs and
+ * already claiming everything available, no pit can exist by definition.
+ *
+ * Returns null when there is no pit; otherwise returns the optimal lower
+ * income, the discretionary delta it would create, and the list of benefit
+ * programs the optimal income qualifies for that the current income does
+ * not.
+ */
+export interface IncomePit {
+  /** Annual gross income at which discretionary peaks below current. */
+  optimalGross: number;
+  /** Annual discretionary at the optimal lower income. */
+  optimalDiscretionary: number;
+  /** Annual discretionary at the current income. */
+  currentDiscretionary: number;
+  /**
+   * The annual delta — how much more (in $/yr) the household would have
+   * at the optimal lower income vs. now. Always positive.
+   */
+  delta: number;
+  /**
+   * Programs the optimal income qualifies for that current income does
+   * not. These are the programs whose loss creates the pit.
+   */
+  programsGained: BenefitId[];
+}
+
+export function findIncomePit(
+  input: Omit<BudgetInput, 'claimedBenefits'> & { stepSize?: number },
+): IncomePit | null {
+  const stepSize = input.stepSize ?? 500;
+  const allBenefits = new Set<string>(BENEFIT_IDS);
+  const totalIncome = input.incomeA + (input.incomeB ?? 0);
+  if (totalIncome <= 0) return null;
+
+  // Compute current discretionary with everything claimed.
+  const current = computeBudget({ ...input, claimedBenefits: allBenefits });
+  const currentDisc = current.annualDiscretionary;
+
+  // Sweep $0 → currentGross at stepSize granularity, varying incomeA.
+  // Holding incomeB fixed mirrors how CliffCurve presents the sweep.
+  let bestGross = totalIncome;
+  let bestDisc = currentDisc;
+  for (let g = 0; g < totalIncome; g += stepSize) {
+    const sweepIncomeA = Math.max(0, g - (input.incomeB ?? 0));
+    const r = computeBudget({
+      ...input,
+      incomeA: sweepIncomeA,
+      claimedBenefits: allBenefits,
+    });
+    if (r.annualDiscretionary > bestDisc) {
+      bestDisc = r.annualDiscretionary;
+      bestGross = g;
+    }
+  }
+
+  if (bestGross >= totalIncome || bestDisc <= currentDisc) return null;
+
+  // Identify which programs the optimal income qualifies for that the
+  // current does not. Re-check eligibility at both points using the
+  // benefits API directly (cheaper than parsing computeBudget output).
+  const baseInputs = {
+    householdSize: current.householdSize,
+    state: current.cityData.state,
+    adults: current.adults,
+    kids: current.householdSize - current.adults,
+    monthlyHealthcareCost:
+      current.expenses.Healthcare +
+      (current.benefitsApplied['Medicaid'] ?? 0) +
+      (current.benefitsApplied['CHIP'] ?? 0),
+    monthlyHealthcareSingle: current.cityData.healthSingle,
+  };
+  const programsGained: BenefitId[] = [];
+  for (const id of BENEFIT_IDS) {
+    const atOptimal = checkBenefit(id, { ...baseInputs, grossIncome: bestGross });
+    const atCurrent = checkBenefit(id, { ...baseInputs, grossIncome: totalIncome });
+    if (atOptimal.eligible && !atCurrent.eligible) {
+      programsGained.push(id);
+    }
+  }
+
+  return {
+    optimalGross: bestGross,
+    optimalDiscretionary: bestDisc,
+    currentDiscretionary: currentDisc,
+    delta: bestDisc - currentDisc,
+    programsGained,
+  };
+}


### PR DESCRIPTION
## Summary
- New `CliffCurve` section that sweeps gross income $0 → max($200K, 1.5× current) for the active household and plots annual discretionary income, auto-claiming SNAP / Medicaid / CHIP at every step so the eligibility cliffs show up as vertical drops.
- Dashed vertical `ReferenceLine`s mark each program's cutoff (FPL × program multiplier × state policy); a green dot anchors the user's current income on the curve.
- Editorial caption auto-quantifies the largest cliff drop ("at \$X, one more dollar costs ~\$Y a year").
- Updated SNAP and Medicaid roadmap-item summaries to note the cliff-viz piece shipped (status unchanged — those items still have other unshipped scope).

The cliff math was already baked into `computeBudget` — this view just makes the discontinuities legible.

## Test plan
- [ ] `yarn tsc --noEmit` and `yarn test --run` pass (verified locally).
- [ ] Open the home page in the dev server, scroll to the new section after the city comparison.
- [ ] Try TX with kids — the parent-Medicaid cliff should appear at a startlingly low income (~17% FPL).
- [ ] Try SF with kids — CHIP cutoff should sit very high; SNAP and Medicaid cliffs sit closer together.
- [ ] Try CA, no kids, single — only Medicaid (138% FPL) and SNAP cliffs should appear; no CHIP line.
- [ ] Move the income slider — the green dot should track along the curve and the editorial caption should remain accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)