### PR TITLE
Fix audit-links workflow: use PR-based commit

### DIFF
--- a/.github/workflows/audit-links.yml
+++ b/.github/workflows/audit-links.yml
@@ -47,23 +47,33 @@ jobs:
       - name: Run link audit
         run: yarn check-links
 
-      - name: Commit refreshed audit data
-        run: |
-          # Stage status.md + the dated TSV (per-day history) + latest.tsv
-          # (stable filename the /sources page imports). The [skip ci] tag
-          # prevents this commit from re-triggering the workflow.
-          if ! git diff --quiet -- audit/links/status.md audit/links/results/ \
-              || [ -n "$(git ls-files --others --exclude-standard audit/links/results/)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add audit/links/status.md audit/links/results/
-            git commit -m "Audit: refresh link-status data [skip ci]"
-            git push
-          else
-            echo "No audit data changes to commit."
-          fi
+      - name: Open PR with refreshed audit data
+        # Switched from `git push origin main` to a PR-based flow because
+        # branch protection on main rejects direct pushes from the bot.
+        # peter-evans/create-pull-request is idempotent: it diffs the
+        # working tree against main, skips the PR entirely when there's
+        # nothing to commit, and updates the existing PR (same branch
+        # name) when a previous run is still open. The PR can be merged
+        # manually or by enabling repo-level auto-merge.
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: |
+            audit/links/status.md
+            audit/links/results/
+          branch: audit/links-refresh
+          commit-message: 'Audit: refresh link-status data'
+          title: 'Audit: refresh link-status data'
+          body: |
+            Automated link-audit refresh.
+
+            Updated by `.github/workflows/audit-links.yml`.
+          labels: audit
+          delete-branch: true
 
       - name: Seed GitHub issues for newly broken links
+        # Always runs, regardless of whether the PR step found changes —
+        # broken-link issues should be opened either way.
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node audit/links/seed-issues.mjs

--- a/.github/workflows/audit-links.yml
+++ b/.github/workflows/audit-links.yml
@@ -22,6 +22,12 @@ on:
 permissions:
   contents: write
   issues: write
+  # Needed by peter-evans/create-pull-request to open the audit-refresh PR.
+  # Note: the default GITHUB_TOKEN doesn't trigger pull_request workflows on
+  # PRs it opens, so CI checks won't run on the audit-refresh PR. That's
+  # acceptable here — the PR only changes machine-generated audit data, no
+  # code, so the CI checks (lint/typecheck/test) wouldn't be meaningful.
+  pull-requests: write
 
 concurrency:
   group: audit-links
@@ -71,8 +77,11 @@ jobs:
           delete-branch: true
 
       - name: Seed GitHub issues for newly broken links
-        # Always runs, regardless of whether the PR step found changes —
-        # broken-link issues should be opened either way.
+        # Runs regardless of the PR step's outcome — issue tracking
+        # shouldn't be coupled to whether new audit data was committable.
+        # Still depends on `yarn check-links` having produced the results
+        # TSV: if the audit itself failed earlier, seed-issues will exit
+        # cleanly without doing anything.
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The nightly link audit has been failing for the last two scheduled runs (May 4 and May 5) with:

\`\`\`
! [remote rejected] main -> main (push declined due to repository rule violations)
\`\`\`

Branch protection on \`main\` now rejects the github-actions bot's direct push, which both (a) loses the refreshed audit data and (b) kills the workflow before \`seed-issues.mjs\` runs — that's why the rolling broken-link tracking issue stopped updating after May 3.

## Fix
Switch the commit step from a raw \`git push origin main\` to [peter-evans/create-pull-request@v7](https://github.com/peter-evans/create-pull-request), which:
- Opens (or updates) a PR on the \`audit/links-refresh\` branch
- Is idempotent — skips entirely when there's nothing to commit
- Reuses the same PR across runs so we don't get a flood of stale audit PRs
- Doesn't need to bypass branch protection

The seed-issues step is also marked \`if: always()\` so broken-link issues continue to be opened regardless of the PR step's outcome.

## Test plan
- [ ] Manually trigger the workflow via Actions tab after merge — should either skip the PR (no data changes) or open one targeting \`audit/links-refresh\`.
- [ ] Confirm seed-issues.mjs runs and the broken-link tracking issue updates.
- [ ] If the audit PR opens, merging it should fast-forward the data into main without further intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)