### PR TITLE
seed-issues.mjs: include 000ERR in ACTIONABLE/error filters

### DIFF
--- a/audit/links/seed-issues.mjs
+++ b/audit/links/seed-issues.mjs
@@ -60,7 +60,11 @@ const SOURCES_TS = resolve(ROOT, 'src/data/sources.ts');
 const REPO = 'TheBudgetAtlas/thebudgetatlas';
 const LABEL = 'audit:link';
 
-const ACTIONABLE = new Set(['404', '000', 'ERR', '999']);
+// '000ERR' is the actual single merged code that check.sh writes for
+// DNS/TLS/timeout failures (despite the code list above splitting them
+// for documentation). Keep both spellings to be safe; UI side uses the
+// merged spelling too — see src/lib/sourceStatus.tsx BROKEN_STATUS_CODES.
+const ACTIONABLE = new Set(['404', '000', '000ERR', 'ERR', '999']);
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -230,7 +234,7 @@ function buildTitle(broken) {
   const counts = { 404: 0, errors: 0, anti: 0 };
   for (const r of broken) {
     if (r.status === '404') counts['404']++;
-    else if (r.status === '000' || r.status === 'ERR') counts.errors++;
+    else if (r.status === '000' || r.status === '000ERR' || r.status === 'ERR') counts.errors++;
     else if (r.status === '999') counts.anti++;
   }
   const parts = [];
@@ -255,7 +259,9 @@ function extractCheckedUrls(existingBody) {
 
 function buildBody(broken, checkedUrls) {
   const by404 = broken.filter((r) => r.status === '404');
-  const byErrors = broken.filter((r) => r.status === '000' || r.status === 'ERR');
+  const byErrors = broken.filter(
+    (r) => r.status === '000' || r.status === '000ERR' || r.status === 'ERR',
+  );
   const byAnti = broken.filter((r) => r.status === '999');
 
   const lines = [


### PR DESCRIPTION
## Summary
This commit was on PR #152's branch but didn't make it into the merge — opening it standalone.

The actual code \`check.sh\` writes for DNS/TLS/timeout failures is the single merged token \`000ERR\`, but \`ACTIONABLE\` only had separate \`'000'\` and \`'ERR'\` entries — so all DNS/timeout failures get silently dropped from the rolling broken-citation issue. The /sources page (\`BROKEN_STATUS_CODES\` in \`src/lib/sourceStatus.tsx\`) correctly uses \`'000ERR'\`, which is why /sources currently reports 5 broken while the rolling issue (#116) only shows the 999 anti-bot ones.

Same fix applied to \`buildTitle\`'s bucket counter and \`buildBody\`'s errors-group filter so the rendered title and sections include the timeout entries too.

## Test plan
- [ ] Local dry-run reports 6 broken (2 hard 404, 3 errors, 1 anti-bot) against current main data — matching what /sources shows
- [ ] Next audit run updates issue #116 with the missing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)