### PR TITLE
Audit backend A: D1 stand-up + dual-write

### DIFF
--- a/.github/workflows/audit-links.yml
+++ b/.github/workflows/audit-links.yml
@@ -51,6 +51,13 @@ jobs:
         run: yarn install --immutable
 
       - name: Run link audit
+        env:
+          # Dual-write phase: check.sh POSTs the new run to the D1-backed
+          # API in addition to writing TSVs to the repo. Until PR B
+          # switches the site to read from the API, the TSV remains the
+          # source of truth — a failed POST is logged but doesn't fail
+          # the audit step.
+          AUDIT_WRITE_TOKEN: ${{ secrets.AUDIT_WRITE_TOKEN }}
         run: yarn check-links
 
       - name: Open PR with refreshed audit data

--- a/.gitignore
+++ b/.gitignore
@@ -44,8 +44,7 @@ pnpm-debug.log*
 
 # Env
 .env
-.env.local
-.env.*.local
+.env.*
 
 # OS
 Thumbs.db

--- a/audit/links/README.md
+++ b/audit/links/README.md
@@ -4,7 +4,7 @@ Reproducible audit of every external URL cited from the codebase — does it sti
 
 ## How it works
 
-1. **`check.sh`** extracts every `http(s)://` URL from [`src/data/sources.ts`](../../src/data/sources.ts) — the citation registry — hits each with curl, and writes a dated TSV to `results/`. Other URLs in the codebase (font CDN preconnects, repo links, build artifacts) aren't checked: only declared citations are auditable, by design.
+1. **`check.sh`** extracts every `http(s)://` URL from [`src/data/sources.ts`](../../src/data/sources.ts) — the citation registry — hits each with curl, and writes a dated TSV to `results/`. Other URLs in the codebase (font CDN preconnects, repo links, build artifacts) aren't checked: only declared citations are auditable, by design. When `AUDIT_WRITE_TOKEN` is set, the run is also POSTed to the D1-backed audit API (see "Backend" below).
 2. **`reviewed.tsv`** is the unified resolution log (see below). One row per `id · date · reviewer · kind · notes` event — keyed by stable source slug, not URL, so review history follows a citation across URL changes. `kind` is `human` (eyes-on-source) or `ai` (AI involved in proposing/extracting). **Rows are append-only**: existing rows can't be modified, removed, or reordered (CI enforces this via `scripts/check-reviewed-immutable.mjs`). If a past review needs correction, append a new row that supersedes it — don't edit history.
 3. **`results/<date>.tsv`** captures the union: machine status (does it load?) + human review state (did someone verify the content?).
 
@@ -137,6 +137,25 @@ To run manually: `yarn audit:seed-issues` (or `--dry-run` to preview).
 ## At-a-glance status
 
 [`status.md`](./status.md) is the human-readable view of every cited source — auto-generated each audit run. One row per source, with current curl status, who added it, when, and any human-review history. Sort order is broken-first so the things needing attention surface immediately.
+
+## Backend (D1)
+
+Run history lives in a Cloudflare D1 database (`budget-atlas-audit`) bound to the site's worker. The schema is in [`worker/schema.sql`](../../worker/schema.sql); the worker entry point in [`worker/index.ts`](../../worker/index.ts) exposes:
+
+- `POST /api/audit/runs` — upsert a run (bearer auth, `AUDIT_WRITE_TOKEN`).
+- `GET  /api/audit/latest` — most-recent run as JSON.
+- `GET  /api/audit/runs/:date` — specific run.
+- `GET  /api/audit/history?url=…` — last 30 statuses for a URL.
+
+**Stand-up status (PR A):** the nightly job now dual-writes — TSVs to the repo *and* a POST to the API. The site (and `seed-issues.mjs`) still read from the in-repo TSVs; the backend exists but isn't on the read path yet.
+
+**One-time backfill** (after `wrangler d1 create budget-atlas-audit` + `wrangler d1 execute … --file=worker/schema.sql`):
+
+```sh
+AUDIT_WRITE_TOKEN=<token> node audit/links/backfill-d1.mjs
+```
+
+PRs B and C will move the site's reads to the API and finally remove the in-repo TSVs.
 
 ## Contributing a fix
 

--- a/audit/links/README.md
+++ b/audit/links/README.md
@@ -147,7 +147,7 @@ Run history lives in a Cloudflare D1 database (`budget-atlas-audit`) bound to th
 - `GET  /api/audit/runs/:date` — specific run.
 - `GET  /api/audit/history?url=…` — last 30 statuses for a URL.
 
-**Stand-up status (PR A):** the nightly job now dual-writes — TSVs to the repo *and* a POST to the API. The site (and `seed-issues.mjs`) still read from the in-repo TSVs; the backend exists but isn't on the read path yet.
+**Stand-up status (PR A):** the nightly job now dual-writes — TSVs to the repo _and_ a POST to the API. The site (and `seed-issues.mjs`) still read from the in-repo TSVs; the backend exists but isn't on the read path yet.
 
 **One-time backfill** (after `wrangler d1 create budget-atlas-audit` + `wrangler d1 execute … --file=worker/schema.sql`):
 

--- a/audit/links/backfill-d1.mjs
+++ b/audit/links/backfill-d1.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Seed the audit-backend D1 database from existing dated TSVs.
+//
+// One-shot bootstrap: reads every audit/links/results/YYYY-MM-DD.tsv and
+// POSTs each as a run. Idempotent (the worker upserts), so re-running is
+// safe.
+//
+// Usage:
+//   API_BASE=https://thebudgetatlas.com \
+//     AUDIT_WRITE_TOKEN=... \
+//     node audit/links/backfill-d1.mjs
+//
+//   # Dry-run prints what would be sent without hitting the network.
+//   node audit/links/backfill-d1.mjs --dry-run
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RESULTS_DIR = resolve(__dirname, 'results');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const API_BASE = process.env.API_BASE ?? 'https://thebudgetatlas.com';
+const TOKEN = process.env.AUDIT_WRITE_TOKEN;
+
+if (!DRY_RUN && !TOKEN) {
+  console.error('AUDIT_WRITE_TOKEN env var required (or pass --dry-run).');
+  process.exit(1);
+}
+
+const dated = readdirSync(RESULTS_DIR)
+  .filter((f) => /^\d{4}-\d{2}-\d{2}\.tsv$/.test(f))
+  .sort();
+
+console.log(`→ Found ${dated.length} dated TSVs to backfill.`);
+
+for (const file of dated) {
+  const runDate = file.replace('.tsv', '');
+  const text = readFileSync(resolve(RESULTS_DIR, file), 'utf8');
+  const results = text
+    .split('\n')
+    .slice(1)
+    .filter(Boolean)
+    .map((line) => {
+      const [status, url, final_url] = line.split('\t');
+      return { status, url, final_url: final_url || null };
+    });
+
+  if (DRY_RUN) {
+    console.log(`  ${runDate}: ${results.length} rows (dry-run)`);
+    continue;
+  }
+
+  const res = await fetch(`${API_BASE}/api/audit/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${TOKEN}`,
+    },
+    body: JSON.stringify({ run_date: runDate, results }),
+  });
+  if (!res.ok) {
+    console.error(`  ${runDate}: FAILED (${res.status} ${res.statusText})`);
+    console.error(await res.text());
+    process.exit(1);
+  }
+  const body = await res.json();
+  console.log(`  ${runDate}: ${body.inserted} rows`);
+}
+
+console.log('✨ Done.');

--- a/audit/links/check.sh
+++ b/audit/links/check.sh
@@ -106,6 +106,22 @@ node "$DIR/generate-status.mjs"
 # overwritten; dated files in results/ remain as the per-day audit history.
 cp "$OUT" "$DIR/results/latest.tsv"
 
+# Dual-write to the D1-backed audit API. Best-effort during the backend
+# stand-up phase: a failed POST shouldn't block the rest of the audit
+# pipeline (PR creation, issue seeding) since the in-repo TSVs remain
+# the source of truth until PR B switches the site to read from the API.
+if [ -n "${AUDIT_WRITE_TOKEN:-}" ]; then
+  echo ""
+  echo "→ Posting run to audit API..."
+  if AUDIT_WRITE_TOKEN="$AUDIT_WRITE_TOKEN" \
+       API_BASE="${AUDIT_API_BASE:-https://thebudgetatlas.com}" \
+       node "$DIR/post-run.mjs" "$OUT" "$DATE"; then
+    echo "  ok"
+  else
+    echo "  WARN: post-run failed; in-repo TSV remains source of truth"
+  fi
+fi
+
 echo ""
 echo "→ Results: $OUT"
 echo ""

--- a/audit/links/post-run.mjs
+++ b/audit/links/post-run.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Post a single TSV run to the audit-backend API.
+//
+// Used by check.sh after a nightly audit completes (and by manual
+// re-runs). Reads a TSV file, parses it into the API's JSON shape, and
+// POSTs to /api/audit/runs with bearer auth.
+//
+// Usage:
+//   AUDIT_WRITE_TOKEN=... node post-run.mjs <tsv-path> <YYYY-MM-DD>
+//
+// Exits 0 on 2xx, non-zero otherwise so check.sh can `if … then`.
+
+import { readFileSync } from 'node:fs';
+
+const [, , tsvPath, runDate] = process.argv;
+if (!tsvPath || !runDate) {
+  console.error('usage: post-run.mjs <tsv-path> <YYYY-MM-DD>');
+  process.exit(2);
+}
+
+const TOKEN = process.env.AUDIT_WRITE_TOKEN;
+const API_BASE = process.env.API_BASE ?? 'https://thebudgetatlas.com';
+if (!TOKEN) {
+  console.error('AUDIT_WRITE_TOKEN required');
+  process.exit(2);
+}
+
+const text = readFileSync(tsvPath, 'utf8');
+const results = text
+  .split('\n')
+  .slice(1)
+  .filter(Boolean)
+  .map((line) => {
+    const [status, url, final_url] = line.split('\t');
+    return { status, url, final_url: final_url || null };
+  });
+
+const res = await fetch(`${API_BASE}/api/audit/runs`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', authorization: `Bearer ${TOKEN}` },
+  body: JSON.stringify({ run_date: runDate, results }),
+});
+if (!res.ok) {
+  console.error(`POST failed: ${res.status} ${res.statusText}`);
+  console.error(await res.text());
+  process.exit(1);
+}
+const body = await res.json();
+console.log(`  inserted ${body.inserted} rows for ${body.run_date}`);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,14 @@ import prettierConfig from 'eslint-config-prettier';
 export default tseslint.config(
   // Ignore generated and vendored output. Everything else is fair game.
   {
-    ignores: ['dist/**', 'build/**', 'node_modules/**', '.vite/**', '.claude/**'],
+    ignores: [
+      'dist/**',
+      'dist-tsbuildinfo/**',
+      'build/**',
+      'node_modules/**',
+      '.vite/**',
+      '.claude/**',
+    ],
   },
 
   // Base JS recommendations.
@@ -71,6 +78,9 @@ export default tseslint.config(
         setInterval: 'readonly',
         clearTimeout: 'readonly',
         clearInterval: 'readonly',
+        // Node 18+ exposes fetch globally (used in audit/links/post-run.mjs
+        // + backfill-d1.mjs to POST to the Cloudflare-hosted audit API).
+        fetch: 'readonly',
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260506.1",
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     }
   },
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "references": [{ "path": "./tsconfig.node.json" }, { "path": "./tsconfig.worker.json" }]
 }

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "isolatedModules": true,
+    "types": ["@cloudflare/workers-types"],
+    "outDir": "./dist-tsbuildinfo"
+  },
+  "include": ["worker"]
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,151 @@
+// Cloudflare Worker entry point.
+//
+// Two responsibilities:
+//   1. Serve the link-audit API at /api/audit/*. Backed by D1.
+//   2. Delegate everything else to the static-asset binding (the SPA).
+//
+// The wrangler.jsonc `assets.run_worker_first` setting routes /api/*
+// to this worker first; all other paths hit the static assets directly,
+// so adding the API doesn't add latency to ordinary page loads.
+//
+// API surface (see audit/links/README.md for the canonical contract):
+//   POST /api/audit/runs        — upsert a run. Bearer-token auth.
+//   GET  /api/audit/latest      — most-recent run as JSON.
+//   GET  /api/audit/runs/:date  — specific run as JSON.
+//   GET  /api/audit/history?url=... — per-URL status history (last 30).
+//
+// Reads are public — the audit data backs the public /sources page,
+// there's nothing sensitive about it. Writes require AUDIT_WRITE_TOKEN
+// (set as a Workers secret + a GitHub Actions secret of the same name).
+
+interface Env {
+  DB: D1Database;
+  ASSETS: Fetcher;
+  AUDIT_WRITE_TOKEN: string;
+}
+
+interface PostBody {
+  run_date: string;
+  results: Array<{ status: string; url: string; final_url?: string | null }>;
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function json(data: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  });
+}
+
+function requireAuth(req: Request, env: Env): Response | null {
+  const auth = req.headers.get('authorization') ?? '';
+  const match = auth.match(/^Bearer\s+(.+)$/);
+  if (!match || match[1] !== env.AUDIT_WRITE_TOKEN) {
+    return json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return null;
+}
+
+async function postRun(req: Request, env: Env): Promise<Response> {
+  const authError = requireAuth(req, env);
+  if (authError) return authError;
+
+  let body: PostBody;
+  try {
+    body = (await req.json()) as PostBody;
+  } catch {
+    return json({ error: 'invalid json' }, { status: 400 });
+  }
+  if (!body || typeof body.run_date !== 'string' || !DATE_RE.test(body.run_date)) {
+    return json({ error: 'run_date must be YYYY-MM-DD' }, { status: 400 });
+  }
+  if (!Array.isArray(body.results)) {
+    return json({ error: 'results must be an array' }, { status: 400 });
+  }
+
+  const runDate = body.run_date;
+  // Idempotent: re-POSTing the same date wipes prior rows for that date
+  // and inserts the new payload. Lets the action retry safely and lets
+  // a manual re-audit overwrite without duplicating.
+  const stmts: D1PreparedStatement[] = [
+    env.DB.prepare('DELETE FROM audit_results WHERE run_date = ?').bind(runDate),
+    env.DB.prepare(
+      'INSERT INTO audit_runs (run_date) VALUES (?) ON CONFLICT(run_date) DO UPDATE SET created_at = unixepoch()',
+    ).bind(runDate),
+  ];
+  const insert = env.DB.prepare(
+    'INSERT INTO audit_results (run_date, url, status, final_url) VALUES (?, ?, ?, ?)',
+  );
+  for (const r of body.results) {
+    if (typeof r.status !== 'string' || typeof r.url !== 'string') continue;
+    stmts.push(insert.bind(runDate, r.url, r.status, r.final_url ?? null));
+  }
+  await env.DB.batch(stmts);
+
+  return json({ ok: true, run_date: runDate, inserted: stmts.length - 2 });
+}
+
+async function getLatest(env: Env): Promise<Response> {
+  const run = await env.DB.prepare(
+    'SELECT run_date, created_at FROM audit_runs ORDER BY run_date DESC LIMIT 1',
+  ).first<{ run_date: string; created_at: number }>();
+  if (!run) return json({ error: 'no runs' }, { status: 404 });
+  const rows = await env.DB.prepare(
+    'SELECT url, status, final_url FROM audit_results WHERE run_date = ? ORDER BY url',
+  )
+    .bind(run.run_date)
+    .all<{ url: string; status: string; final_url: string | null }>();
+  return json({ run_date: run.run_date, created_at: run.created_at, results: rows.results });
+}
+
+async function getRun(date: string, env: Env): Promise<Response> {
+  if (!DATE_RE.test(date)) return json({ error: 'invalid date' }, { status: 400 });
+  const run = await env.DB.prepare('SELECT run_date, created_at FROM audit_runs WHERE run_date = ?')
+    .bind(date)
+    .first<{ run_date: string; created_at: number }>();
+  if (!run) return json({ error: 'not found' }, { status: 404 });
+  const rows = await env.DB.prepare(
+    'SELECT url, status, final_url FROM audit_results WHERE run_date = ? ORDER BY url',
+  )
+    .bind(date)
+    .all<{ url: string; status: string; final_url: string | null }>();
+  return json({ run_date: run.run_date, created_at: run.created_at, results: rows.results });
+}
+
+async function getHistory(url: string, env: Env): Promise<Response> {
+  const rows = await env.DB.prepare(
+    'SELECT run_date, status, final_url FROM audit_results WHERE url = ? ORDER BY run_date DESC LIMIT 30',
+  )
+    .bind(url)
+    .all<{ run_date: string; status: string; final_url: string | null }>();
+  return json({ url, history: rows.results });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    if (path.startsWith('/api/audit/')) {
+      if (request.method === 'POST' && path === '/api/audit/runs') {
+        return postRun(request, env);
+      }
+      if (request.method === 'GET' && path === '/api/audit/latest') {
+        return getLatest(env);
+      }
+      const runMatch = path.match(/^\/api\/audit\/runs\/(.+)$/);
+      if (request.method === 'GET' && runMatch) {
+        return getRun(runMatch[1], env);
+      }
+      if (request.method === 'GET' && path === '/api/audit/history') {
+        const u = url.searchParams.get('url');
+        if (!u) return json({ error: 'url query param required' }, { status: 400 });
+        return getHistory(u, env);
+      }
+      return json({ error: 'not found' }, { status: 404 });
+    }
+
+    return env.ASSETS.fetch(request);
+  },
+};

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -32,10 +32,12 @@ interface PostBody {
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function json(data: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(data), {
-    ...init,
-    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
-  });
+  // Build via the Headers constructor so callers passing a Headers
+  // instance (a valid HeadersInit) don't get silently dropped by an
+  // object spread.
+  const headers = new Headers(init.headers);
+  if (!headers.has('content-type')) headers.set('content-type', 'application/json');
+  return new Response(JSON.stringify(data), { ...init, headers });
 }
 
 function requireAuth(req: Request, env: Env): Response | null {
@@ -65,25 +67,35 @@ async function postRun(req: Request, env: Env): Promise<Response> {
   }
 
   const runDate = body.run_date;
+  // Validate the entire results array up-front so a malformed row
+  // can't quietly truncate the day's data after the DELETE has already
+  // wiped it. All-or-nothing: 400 on any bad row, no DB writes.
+  for (let i = 0; i < body.results.length; i++) {
+    const r = body.results[i];
+    if (!r || typeof r.status !== 'string' || typeof r.url !== 'string') {
+      return json({ error: `results[${i}] must have string status + url` }, { status: 400 });
+    }
+  }
+
   // Idempotent: re-POSTing the same date wipes prior rows for that date
-  // and inserts the new payload. Lets the action retry safely and lets
-  // a manual re-audit overwrite without duplicating.
+  // and inserts the new payload. created_at on audit_runs stays at the
+  // first-seen timestamp (ON CONFLICT DO NOTHING) so the column means
+  // what its name says.
   const stmts: D1PreparedStatement[] = [
     env.DB.prepare('DELETE FROM audit_results WHERE run_date = ?').bind(runDate),
     env.DB.prepare(
-      'INSERT INTO audit_runs (run_date) VALUES (?) ON CONFLICT(run_date) DO UPDATE SET created_at = unixepoch()',
+      'INSERT INTO audit_runs (run_date) VALUES (?) ON CONFLICT(run_date) DO NOTHING',
     ).bind(runDate),
   ];
   const insert = env.DB.prepare(
     'INSERT INTO audit_results (run_date, url, status, final_url) VALUES (?, ?, ?, ?)',
   );
   for (const r of body.results) {
-    if (typeof r.status !== 'string' || typeof r.url !== 'string') continue;
     stmts.push(insert.bind(runDate, r.url, r.status, r.final_url ?? null));
   }
   await env.DB.batch(stmts);
 
-  return json({ ok: true, run_date: runDate, inserted: stmts.length - 2 });
+  return json({ ok: true, run_date: runDate, inserted: body.results.length });
 }
 
 async function getLatest(env: Env): Promise<Response> {

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -1,0 +1,31 @@
+-- Schema for the link-audit backend (D1).
+--
+-- One row per (run_date, url): the curl status from the nightly audit,
+-- plus the resolved final URL after redirects.
+--
+-- audit_runs is a thin metadata table — its primary purpose is recording
+-- *when* a run completed, so the worker can answer "what's the latest
+-- run" without scanning audit_results. Keying on run_date (YYYY-MM-DD)
+-- keeps the table self-describing and lets the action POST idempotently
+-- — re-running a given date overwrites instead of duplicating.
+--
+-- The (url, run_date DESC) index serves the flap-suppression query in
+-- seed-issues.mjs ("last N statuses for this URL"). Composite PK on
+-- (run_date, url) means inserts are deterministic and ON CONFLICT works
+-- without ambiguity.
+
+CREATE TABLE IF NOT EXISTS audit_runs (
+  run_date   TEXT PRIMARY KEY,                      -- YYYY-MM-DD
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()) -- epoch seconds
+);
+
+CREATE TABLE IF NOT EXISTS audit_results (
+  run_date  TEXT NOT NULL REFERENCES audit_runs(run_date) ON DELETE CASCADE,
+  url       TEXT NOT NULL,
+  status    TEXT NOT NULL,
+  final_url TEXT,
+  PRIMARY KEY (run_date, url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_results_url_date
+  ON audit_results(url, run_date DESC);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,7 +21,7 @@
       "binding": "DB",
       "database_name": "budget-atlas-audit",
       // Replace with the id printed by `wrangler d1 create budget-atlas-audit`.
-      "database_id": "REPLACE_ME_AFTER_WRANGLER_D1_CREATE",
+      "database_id": "8e994c5e-6072-4bb5-b999-d75b97425e77",
     },
   ],
   "routes": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,11 +5,25 @@
   "name": "thebudgetatlas",
   "compatibility_date": "2026-05-02",
   "compatibility_flags": ["nodejs_compat"],
+  "main": "./worker/index.ts",
   "assets": {
     "directory": "./dist",
+    "binding": "ASSETS",
     // SPA fallback — equivalent to the old Pages `/* /index.html 200` redirect.
     "not_found_handling": "single-page-application",
+    // Run the worker first only for /api/* paths; static assets keep
+    // their fast-path for everything else (no extra latency on page
+    // loads). The worker delegates non-API requests via env.ASSETS.fetch.
+    "run_worker_first": ["/api/*"],
   },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "budget-atlas-audit",
+      // Replace with the id printed by `wrangler d1 create budget-atlas-audit`.
+      "database_id": "REPLACE_ME_AFTER_WRANGLER_D1_CREATE",
+    },
+  ],
   "routes": [
     {
       "pattern": "thebudgetatlas.com",

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,6 +180,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cloudflare/workers-types@npm:^4.20260506.1":
+  version: 4.20260506.1
+  resolution: "@cloudflare/workers-types@npm:4.20260506.1"
+  checksum: 10c0/71e22ff760d7e5f30ae20061a7b40e0ea38b09b3ca9c5fbf8a384bfa209f5fb0f3f4b16f0b84a496fadb0853dfa993fcd763cc5c8dc0da6a524196c740d989d3
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
@@ -1050,6 +1057,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "budget-atlas@workspace:."
   dependencies:
+    "@cloudflare/workers-types": "npm:^4.20260506.1"
     "@eslint/js": "npm:^10.0.1"
     "@fontsource-variable/fraunces": "npm:^5.2.9"
     "@fontsource/ibm-plex-mono": "npm:^5.2.7"


### PR DESCRIPTION
First of three PRs migrating audit history from in-repo TSVs to a Cloudflare D1 backend. **No site behavior changes in this PR.**

## What this does

- Adds a Worker (`worker/index.ts`) exposing the audit API.
- Adds the D1 schema (`worker/schema.sql`) — two tables, one index. ~10 lines of SQL.
- Wires the worker into `wrangler.jsonc` with `run_worker_first: ['/api/*']` so static page loads keep their zero-overhead fast path.
- Updates the nightly audit to *also* POST each run to the API (best-effort; failure logs a warning but doesn't break the pipeline).
- Adds a one-shot backfill script for the dated TSVs already in the repo.

## API

| Method | Path | Auth | Purpose |
|---|---|---|---|
| POST | `/api/audit/runs` | Bearer `AUDIT_WRITE_TOKEN` | Upsert a run (idempotent — re-POSTing a date overwrites). |
| GET | `/api/audit/latest` | none | Most-recent run as JSON. |
| GET | `/api/audit/runs/:date` | none | Specific run. |
| GET | `/api/audit/history?url=…` | none | Last 30 statuses for a URL. |

Reads are public — the data backs the public `/sources` page.

## Setup before merging (your call)

```sh
wrangler d1 create budget-atlas-audit
# paste the printed database_id into wrangler.jsonc
wrangler d1 execute budget-atlas-audit --remote --file=worker/schema.sql
wrangler secret put AUDIT_WRITE_TOKEN
# add the same token as a GitHub Actions repo secret named AUDIT_WRITE_TOKEN
AUDIT_WRITE_TOKEN=<token> node audit/links/backfill-d1.mjs
```

After backfill, hit `https://thebudgetatlas.com/api/audit/latest` and confirm it returns the most-recent run.

## What's next

- **PR B**: replace the `?raw` TSV import in `src/lib/sourceStatus.tsx` with a fetch to `/api/audit/latest`. Site reads from the backend.
- **PR C**: stop writing TSVs to the repo, remove `audit/links/results/`, drop the audit-refresh PR step from the workflow. `reviewed.tsv` stays — that's authored content.

## Test plan
- [x] `tsc -b` clean (worker compiles against `@cloudflare/workers-types`)
- [x] `yarn build` clean
- [ ] After D1 setup: `node audit/links/backfill-d1.mjs --dry-run` enumerates every dated TSV
- [ ] After backfill: `curl /api/audit/latest` returns the seeded data
- [ ] After backfill: `curl /api/audit/history?url=https://aspe.hhs.gov/...` returns multi-day history
- [ ] After this lands and one nightly run completes: confirm the new run shows up in D1

🤖 Generated with [Claude Code](https://claude.com/claude-code)