### PR TITLE
Roadmap: unify shipped count between kicker and strip header

### DIFF
--- a/src/pages/roadmap/Roadmap.tsx
+++ b/src/pages/roadmap/Roadmap.tsx
@@ -119,11 +119,17 @@ function PlannedList() {
     });
   const inProgress = ROADMAP.filter((i) => i.status === 'in-progress').length;
   const planned = ROADMAP.filter((i) => i.status === 'planned').length;
-  const shippedFromRoadmap = ROADMAP.filter((i) => i.status === 'shipped').length;
+  // Total shipped = roadmap items flipped to 'shipped' + historical
+  // pre-roadmap milestones in SHIPPED[]. The "Already in the model"
+  // strip below renders both as a single list, so the kicker count
+  // here matches what the user sees in that strip — avoids reading
+  // as inconsistent with the strip's "X milestones" header.
+  const shippedTotal =
+    ROADMAP.filter((i) => i.status === 'shipped').length + SHIPPED.length;
   const parts: string[] = [];
   if (inProgress > 0) parts.push(`${inProgress} in progress`);
   parts.push(`${planned} planned`);
-  if (shippedFromRoadmap > 0) parts.push(`${shippedFromRoadmap} shipped (below)`);
+  if (shippedTotal > 0) parts.push(`${shippedTotal} shipped (below)`);
   const kicker = parts.join(' · ');
 
   return (

--- a/src/pages/roadmap/Roadmap.tsx
+++ b/src/pages/roadmap/Roadmap.tsx
@@ -124,8 +124,7 @@ function PlannedList() {
   // strip below renders both as a single list, so the kicker count
   // here matches what the user sees in that strip — avoids reading
   // as inconsistent with the strip's "X milestones" header.
-  const shippedTotal =
-    ROADMAP.filter((i) => i.status === 'shipped').length + SHIPPED.length;
+  const shippedTotal = ROADMAP.filter((i) => i.status === 'shipped').length + SHIPPED.length;
   const parts: string[] = [];
   if (inProgress > 0) parts.push(`${inProgress} in progress`);
   parts.push(`${planned} planned`);


### PR DESCRIPTION
## Summary

`X shipped (below)` on the planned-list kicker showed 6 (only ROADMAP entries with `status: 'shipped'`), while the `Already in the model · X milestones` strip header below showed 10 (roadmap-shipped + historical `SHIPPED[]`). Same page, two different numbers, read as inconsistent — looked hardcoded to a stale value.

Both now derive from the same total. Strip header unchanged; kicker now counts both buckets.

## AI time log

`[skip-time-log]` — trivial one-line copy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)