### PR TITLE
feat: dual-line cliff curve + pit-warning metric switch

### DIFF
--- a/src/data/roadmap.ts
+++ b/src/data/roadmap.ts
@@ -335,6 +335,38 @@ export const ROADMAP: readonly RoadmapItem[] = [
     summary:
       "Use BLS demographic data we already mirror (race, age, education, occupation, composition, tenure) to show where the user's income sits (quintile + percentile), how households at the same income spend differently across cuts, and side-by-side geographic comparisons.",
   },
+  {
+    id: 257,
+    title: 'Section 8 housing vouchers',
+    category: 'Benefits & safety net',
+    status: 'planned',
+    summary:
+      'Section 8 vouchers cap rent at 30% of income for eligible low-income households — the largest line missing from the model. Add as a togglable benefit and surface the discretionary-line shift it produces when the housing safety net actually works as designed.',
+  },
+  {
+    id: 258,
+    title: 'ACA premium tax credits',
+    category: 'Benefits & safety net',
+    status: 'planned',
+    summary:
+      "ACA premium tax credits subsidize marketplace coverage for households 138–400% FPL without employer insurance — omitted by today's universal-ESI assumption. Adding it smooths the Medicaid cliff: post-eligibility households land on subsidized coverage, not full-cost ESI.",
+  },
+  {
+    id: 259,
+    title: 'Child & Dependent Care Credit',
+    category: 'Tax modeling',
+    status: 'planned',
+    summary:
+      'The Child & Dependent Care Credit refunds 20–35% of childcare expenses (capped at $3K/$6K for one/two+ kids) for working parents. Currently unmodeled — childcare is treated as full out-of-pocket. Most meaningful at lower-middle incomes where childcare is biting hardest.',
+  },
+  {
+    id: 260,
+    title: 'Industry compensation profile',
+    category: 'Household detail',
+    status: 'planned',
+    summary:
+      'BLS Employee Benefits Survey by industry loads sector-typical ESI access (~50% restaurants, ~90% tech), employer premium share, 401(k) availability, paid leave, and tipped-income defaults — overridable hints, not gates. Same income looks very different across industries.',
+  },
 ];
 
 /**

--- a/src/lib/cliffs.test.ts
+++ b/src/lib/cliffs.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { findIncomePit, PIT_MIN_DELTA } from '@/lib/cliffs';
+
+describe('findIncomePit', () => {
+  it('returns a real pit when the household is just past a Medicaid cliff', () => {
+    // NYC, married, 2 kids, $46K sole earner — just past NY's Medicaid
+    // expansion cutoff (138% FPL ≈ $45,540 for a household of 4). Dropping
+    // a few hundred dollars to retain Medicaid for both adults yields a
+    // meaningfully bigger total-resources line, since employer family
+    // premium in NYC is several thousand a year.
+    const pit = findIncomePit({
+      city: 'nyc',
+      kids: 2,
+      filing: 'married',
+      lifestyle: 'moderate',
+      hasPartner: true,
+      incomeA: 46000,
+      incomeB: 0,
+    });
+    expect(pit).not.toBeNull();
+    expect(pit!.delta).toBeGreaterThan(1000);
+    expect(pit!.programsGained).toContain('medicaid');
+  });
+
+  it('does NOT fire for the Columbus two-teachers scenario', () => {
+    // The scenario that surfaced the original bug: Columbus, married, 2
+    // kids, $110K combined moderate. On the previous (discretionary) metric
+    // this produced a noisy $9 "you'd be better off at $69.5K" warning,
+    // driven entirely by income-elastic expenses — not a real cliff trap.
+    // On take-home + benefits the household is solidly past the cliff.
+    const pit = findIncomePit({
+      city: 'cmh',
+      kids: 2,
+      filing: 'married',
+      lifestyle: 'moderate',
+      hasPartner: true,
+      incomeA: 56000,
+      incomeB: 54000,
+    });
+    expect(pit).toBeNull();
+  });
+
+  it('still fires when the household is sitting inside a real cliff trough', () => {
+    // Same Columbus configuration but at $70,500 — just past the CHIP
+    // cutoff. Going back to $69,500 retains CHIP and nets meaningfully
+    // more total resources. Must surface even on the new metric.
+    const pit = findIncomePit({
+      city: 'cmh',
+      kids: 2,
+      filing: 'married',
+      lifestyle: 'moderate',
+      hasPartner: true,
+      incomeA: 16500,
+      incomeB: 54000,
+    });
+    expect(pit).not.toBeNull();
+    expect(pit!.programsGained).toContain('chip');
+    expect(pit!.delta).toBeGreaterThanOrEqual(PIT_MIN_DELTA);
+  });
+
+  it('respects the minDelta override', () => {
+    // Forcing minDelta=0 on a configuration with no genuine pit still
+    // returns null — the floor is a filter, not a fabricator.
+    const pit = findIncomePit({
+      city: 'cmh',
+      kids: 0,
+      filing: 'single',
+      lifestyle: 'moderate',
+      hasPartner: false,
+      incomeA: 75000,
+      incomeB: 0,
+      minDelta: 0,
+    });
+    expect(pit).toBeNull();
+  });
+});

--- a/src/lib/cliffs.ts
+++ b/src/lib/cliffs.ts
@@ -75,10 +75,19 @@ export function computePitZones<P extends { gross: number }>(
 
 /**
  * "Pit" detection: at the current scenario, is there an income *below* the
- * current one where the household would end up with *more* annual
- * discretionary income? That happens when raising income across a benefit
- * eligibility cutoff costs more in lost benefits than it gained in
- * paycheck — the cliff trap.
+ * current one where the household would end up with *more* annual total
+ * resources (take-home + benefit value)? That happens when raising income
+ * across a benefit eligibility cutoff costs more in lost benefits than it
+ * gained in paycheck — the cliff trap.
+ *
+ * Why total resources, not discretionary: discretionary subtracts modeled
+ * expenses, and modeled expenses scale with income (lifestyle elasticity,
+ * CEX quintile steps). Using discretionary as the pit metric conflates two
+ * different stories — the genuine benefits cliff (a one-time hit at the
+ * threshold) and the lifestyle-inflation tail that lingers after it — and
+ * makes the "pit" look much wider than the policy reality. Take-home +
+ * benefits matches the metric the cliff curve plots, so the warning and
+ * the chart agree.
  *
  * The sweep auto-claims every benefit at every income point so we measure
  * the genuinely optimal outcome at each income level (not whatever the user
@@ -86,17 +95,17 @@ export function computePitZones<P extends { gross: number }>(
  * already claiming everything available, no pit can exist by definition.
  *
  * Returns null when there is no pit; otherwise returns the optimal lower
- * income, the discretionary delta it would create, and the list of benefit
+ * income, the resources delta it would create, and the list of benefit
  * programs the optimal income qualifies for that the current income does
  * not.
  */
 export interface IncomePit {
-  /** Annual gross income at which discretionary peaks below current. */
+  /** Annual gross income at which total resources peaks below current. */
   optimalGross: number;
-  /** Annual discretionary at the optimal lower income. */
-  optimalDiscretionary: number;
-  /** Annual discretionary at the current income. */
-  currentDiscretionary: number;
+  /** Annual take-home + benefit value at the optimal lower income. */
+  optimalResources: number;
+  /** Annual take-home + benefit value at the current income. */
+  currentResources: number;
   /**
    * The annual delta — how much more (in $/yr) the household would have
    * at the optimal lower income vs. now. Always positive.
@@ -109,36 +118,60 @@ export interface IncomePit {
   programsGained: BenefitId[];
 }
 
+/**
+ * Minimum annual delta required to surface a pit. Below this floor the
+ * "pit" is a wash — the lost paycheck and the kept benefits cancel out to
+ * within modeling noise (premium rounding, FICA per-earner edges, etc.),
+ * and the warning's "more than offsetting the lost paycheck" copy oversells
+ * a trivial difference. $500/yr is roughly $40/mo — a small but real gap.
+ */
+export const PIT_MIN_DELTA = 500;
+
+/** Total resources = take-home + annualized benefit value. Matches the
+ *  metric the cliff curve plots, so warning + chart can't drift. */
+function totalResources(r: { netIncome: number; totalBenefits: number }): number {
+  return r.netIncome + r.totalBenefits * 12;
+}
+
 export function findIncomePit(
-  input: Omit<BudgetInput, 'claimedBenefits'> & { stepSize?: number },
+  input: Omit<BudgetInput, 'claimedBenefits'> & { stepSize?: number; minDelta?: number },
 ): IncomePit | null {
   const stepSize = input.stepSize ?? 500;
+  const minDelta = input.minDelta ?? PIT_MIN_DELTA;
   const allBenefits = new Set<string>(BENEFIT_IDS);
   const totalIncome = input.incomeA + (input.incomeB ?? 0);
   if (totalIncome <= 0) return null;
 
-  // Compute current discretionary with everything claimed.
+  // Compute current total resources with everything claimed.
   const current = computeBudget({ ...input, claimedBenefits: allBenefits });
-  const currentDisc = current.annualDiscretionary;
+  const currentRes = totalResources(current);
 
-  // Sweep $0 → currentGross at stepSize granularity, varying incomeA.
-  // Holding incomeB fixed mirrors how CliffCurve presents the sweep.
+  // Sweep $0 → currentGross at stepSize granularity, scaling both earners
+  // proportionally to their current ratio. Mirrors how CliffCurve presents
+  // the sweep — and matters more than it looks: holding incomeB fixed
+  // collapses every g < incomeB onto the same household income, making the
+  // sweep blind to actual low-income behavior in dual-earner scenarios.
+  const ratioB = totalIncome > 0 ? (input.incomeB ?? 0) / totalIncome : 0;
   let bestGross = totalIncome;
-  let bestDisc = currentDisc;
+  let bestRes = currentRes;
   for (let g = 0; g < totalIncome; g += stepSize) {
-    const sweepIncomeA = Math.max(0, g - (input.incomeB ?? 0));
+    const sweepIncomeB = Math.round(g * ratioB);
+    const sweepIncomeA = g - sweepIncomeB;
     const r = computeBudget({
       ...input,
       incomeA: sweepIncomeA,
+      incomeB: sweepIncomeB,
       claimedBenefits: allBenefits,
     });
-    if (r.annualDiscretionary > bestDisc) {
-      bestDisc = r.annualDiscretionary;
+    const res = totalResources(r);
+    if (res > bestRes) {
+      bestRes = res;
       bestGross = g;
     }
   }
 
-  if (bestGross >= totalIncome || bestDisc <= currentDisc) return null;
+  if (bestGross >= totalIncome || bestRes <= currentRes) return null;
+  if (bestRes - currentRes < minDelta) return null;
 
   // Identify which programs the optimal income qualifies for that the
   // current does not. Re-check eligibility at both points using the
@@ -166,9 +199,9 @@ export function findIncomePit(
 
   return {
     optimalGross: bestGross,
-    optimalDiscretionary: bestDisc,
-    currentDiscretionary: currentDisc,
-    delta: bestDisc - currentDisc,
+    optimalResources: bestRes,
+    currentResources: currentRes,
+    delta: bestRes - currentRes,
     programsGained,
   };
 }

--- a/src/pages/atlas/CliffCurve.tsx
+++ b/src/pages/atlas/CliffCurve.tsx
@@ -32,20 +32,41 @@ import { SectionTitle } from '@/components/ui';
 interface SweepPoint {
   gross: number;
   takeHomePlusBenefits: number;
+  /** Annual discretionary — take-home + benefits − modeled CEX-blended
+   *  expenses. Plotted as a secondary line beneath the primary metric. The
+   *  gap between the two lines IS the household's expense burden at every
+   *  income; widening of the gap as income grows IS lifestyle inflation. */
+  discretionary: number;
   benefits: number;
 }
 
-// Only one view now: take-home pay plus the dollar value of every safety-net
-// benefit the household qualifies for (Medicaid, CHIP, SNAP). The total cash
-// + in-kind resources reaching the household. We previously offered
-// Discretionary and Take-home toggles too, but they cluttered the chrome and
-// the cliff story reads cleanly off this single measure: drops are the
-// dollar value of programs the household just lost.
+// Primary metric: take-home pay plus the dollar value of every safety-net
+// benefit the household qualifies for (Medicaid, CHIP, SNAP). Drives the
+// y-axis, the pit-zone math, the cliff-drop captions, and the user-point
+// dot — every "where do you land?" question reads off this line.
+//
+// Why two lines now: the chart originally had toggles between take-home,
+// discretionary, and take-home+benefits, which were stripped because
+// discretionary was too noisy to trust against the cliff drops. The
+// four-axis CEX blend makes discretionary a real signal: the gap between
+// take-home+benefits and discretionary is income-elastic spending — what
+// gets eaten before the marginal dollar becomes free to spend. Plotting
+// both as a dual-line overlay (decided in /design-lab#discretionary-overlay)
+// shows the lifestyle-inflation tail of each cliff without re-introducing
+// chrome toggles.
 const METRIC = {
   longLabel: 'Annual take-home pay + benefit value',
   key: 'takeHomePlusBenefits' as const,
   unitNoun: 'total resources',
 } satisfies { longLabel: string; key: keyof SweepPoint; unitNoun: string };
+
+/** Secondary metric — discretionary income, after modeled expenses. */
+const SECONDARY_METRIC = {
+  shortLabel: 'Discretionary',
+  longLabel: 'Annual discretionary (after expenses)',
+  key: 'discretionary' as const,
+  unitNoun: 'discretionary',
+} satisfies { shortLabel: string; longLabel: string; key: keyof SweepPoint; unitNoun: string };
 
 // Pixel widths the chart layout depends on. The Y-axis width includes the
 // rotated axis label; the right margin and small slop are part of the
@@ -212,6 +233,7 @@ export function CliffCurve({
       out.push({
         gross: g,
         takeHomePlusBenefits: Math.round(r.netIncome + annualBenefits),
+        discretionary: Math.round(r.annualDiscretionary),
         benefits: Math.round(annualBenefits),
       });
     }
@@ -491,6 +513,15 @@ export function CliffCurve({
               ))}
               <Line
                 type="linear"
+                dataKey={SECONDARY_METRIC.key}
+                stroke={T.warning}
+                strokeWidth={1.5}
+                strokeDasharray="4 3"
+                dot={false}
+                isAnimationActive={false}
+              />
+              <Line
+                type="linear"
                 dataKey={metricMeta.key}
                 stroke={T.ink}
                 strokeWidth={2}
@@ -536,6 +567,30 @@ export function CliffCurve({
               }}
             />
             Your current income ({fmt(currentGross)})
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 14,
+                height: 0,
+                borderTop: `2px solid ${T.ink}`,
+                verticalAlign: 'middle',
+              }}
+            />
+            Take-home + benefit value
+          </span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <span
+              style={{
+                display: 'inline-block',
+                width: 14,
+                height: 0,
+                borderTop: `2px dashed ${T.warning}`,
+                verticalAlign: 'middle',
+              }}
+            />
+            Discretionary (after expenses)
           </span>
           {pitZones.length > 0 && (
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
@@ -720,7 +775,8 @@ function CliffTooltip({
   const gross = typeof label === 'number' ? label : Number(label);
   const point = payload[0]?.payload as SweepPoint | undefined;
   if (!point) return null;
-  const value = point.takeHomePlusBenefits;
+  const primary = point.takeHomePlusBenefits;
+  const discretionary = point.discretionary;
   const activePrograms = cliffs.filter((c) => gross <= c.gross);
   return (
     <div
@@ -732,9 +788,18 @@ function CliffTooltip({
         fontSize: rem(12),
       }}
     >
-      <div style={{ color: T.inkMuted, marginBottom: 2 }}>Gross {fmt(gross)}/yr</div>
-      <div style={{ fontFamily: fonts.mono, color: value >= 0 ? T.positive : T.accent }}>
-        {fmt(value)}/yr {metric.unitNoun}
+      <div style={{ color: T.inkMuted, marginBottom: 4 }}>Gross {fmt(gross)}/yr</div>
+      <div style={{ fontFamily: fonts.mono, color: primary >= 0 ? T.ink : T.accent }}>
+        {fmt(primary)}/yr {metric.unitNoun}
+      </div>
+      <div
+        style={{
+          fontFamily: fonts.mono,
+          color: discretionary >= 0 ? T.warning : T.accent,
+          marginTop: 2,
+        }}
+      >
+        {fmt(discretionary)}/yr discretionary
       </div>
       {activePrograms.length > 0 && (
         <div style={{ color: T.inkMuted, marginTop: 4 }}>

--- a/src/pages/atlas/PitWarning.tsx
+++ b/src/pages/atlas/PitWarning.tsx
@@ -73,11 +73,11 @@ export function PitWarning({
         ⚠ You're in a benefits cliff
       </div>
       <div style={{ fontFamily: fonts.body, fontSize: rem(14), color: T.ink, lineHeight: 1.5 }}>
-        At {fmt(incomeA + incomeB)}/yr, this household is left with{' '}
-        <strong>{fmt(pit.currentDiscretionary)}/yr</strong> after taxes and expenses. At{' '}
+        At {fmt(incomeA + incomeB)}/yr, this household has{' '}
+        <strong>{fmt(pit.currentResources)}/yr</strong> in take-home + benefit value. At{' '}
         <strong>{fmt(pit.optimalGross)}/yr</strong> — earning roughly{' '}
         {fmt(incomeA + incomeB - pit.optimalGross)} less — they'd have{' '}
-        <strong>{fmt(pit.optimalDiscretionary)}/yr</strong>, a gain of{' '}
+        <strong>{fmt(pit.optimalResources)}/yr</strong>, a gain of{' '}
         <strong style={{ color: T.warning }}>{fmt(pit.delta)}/yr</strong>.
       </div>
       {programs && (

--- a/src/pages/design-lab/DesignLab.tsx
+++ b/src/pages/design-lab/DesignLab.tsx
@@ -40,6 +40,7 @@ import {
   snapIncomeLimitFpl,
 } from '@/data/benefits';
 import { getCityData } from '@/data/cities';
+import { SCENARIOS } from '@/data/scenarios';
 
 /**
  * Each lab section gets an entry here. The sidebar reads this list to
@@ -63,6 +64,16 @@ interface LabSection {
   readonly decidedNote?: string;
 }
 const LAB_SECTIONS: ReadonlyArray<LabSection> = [
+  {
+    id: 'discretionary-overlay',
+    nav: 'Discretionary overlay',
+    count: 4,
+    Component: SectionDiscretionaryOverlay,
+    status: 'decided',
+    decidedAs: 'V1 — dual-line overlay on the same axes',
+    decidedNote:
+      "Sweeping the scenario picker across rural Wyoming / Columbus / SF told the story: the discretionary line behaves correctly across household shapes — flat-then-plateau where the safety net does the work plus lifestyle inflation absorbs the rest, slope-up where it doesn't. V3 (filled diff-band) overclaimed the lifestyle-inflation gap visually for the average case; V2 (small-multiple) spent too much vertical real estate; V4 (toggle revival) is the right answer if we ever decide one line is enough but didn't beat seeing both at once. Shipped to production CliffCurve as the second line.",
+  },
   {
     id: 'blend-ladder',
     nav: 'Blend-trace ladder',
@@ -2840,6 +2851,10 @@ const CLIFF_COLORS: Record<string, string> = {
 interface CliffPoint {
   gross: number;
   discretionary: number;
+  /** Annual take-home + benefit value. Same formula CliffCurve plots in
+   *  production. Carried alongside `discretionary` so variations can plot
+   *  either metric — or both layered — without re-doing the sweep. */
+  takeHomePlusBenefits: number;
 }
 
 interface CliffMark {
@@ -2870,12 +2885,21 @@ function useCliffScenario(scenario: CliffScenario): {
     const maxGross = Math.max(120_000, Math.ceil((currentGross * 1.5) / 1000) * 1000);
     const stepSize = 500;
 
+    // Scale both earners proportionally to current ratio so the sweep
+    // represents the household actually earning $g, not just earner A
+    // varying while earner B sits frozen. Without this, every g below
+    // `incomeB` computes the same household income and the curve is flat
+    // until g passes incomeB. Mirrors production CliffCurve.
+    const totalCurrent = scenario.incomeA + scenario.incomeB;
+    const ratioB = totalCurrent > 0 ? scenario.incomeB / totalCurrent : 0;
+
     const points: CliffPoint[] = [];
     for (let g = 0; g <= maxGross; g += stepSize) {
-      const sweepIncomeA = Math.max(0, g - scenario.incomeB);
+      const sweepIncomeB = Math.round(g * ratioB);
+      const sweepIncomeA = g - sweepIncomeB;
       const r = computeBudget({
         incomeA: sweepIncomeA,
-        incomeB: scenario.incomeB,
+        incomeB: sweepIncomeB,
         hasPartner: scenario.hasPartner,
         filing: scenario.filing,
         city: scenario.city,
@@ -2883,7 +2907,11 @@ function useCliffScenario(scenario: CliffScenario): {
         lifestyle: scenario.lifestyle,
         claimedBenefits: allBenefits,
       });
-      points.push({ gross: g, discretionary: Math.round(r.annualDiscretionary) });
+      points.push({
+        gross: g,
+        discretionary: Math.round(r.annualDiscretionary),
+        takeHomePlusBenefits: Math.round(r.netIncome + r.totalBenefits * 12),
+      });
     }
 
     const fplBase = fpl(householdSize);
@@ -3937,7 +3965,14 @@ function useCompoundDemoData(config: CompoundConfig): {
     for (let g = 0; g <= maxGross; g += stepSize) {
       let disc = slope * g + intercept;
       for (const c of sortedPrograms) if (g >= c.gross) disc -= c.drop;
-      points.push({ gross: g, discretionary: Math.round(disc) });
+      // Compound-pit demo has no take-home/benefit decomposition — it's a
+      // synthetic curve to compare attribution styles. Stub the metric so
+      // CliffPoint stays satisfied; nothing in this section reads it.
+      points.push({
+        gross: g,
+        discretionary: Math.round(disc),
+        takeHomePlusBenefits: Math.round(disc),
+      });
     }
 
     const cliffs: CliffMark[] = sortedPrograms.map((c) => ({
@@ -6520,5 +6555,649 @@ function LadderV2() {
         ))}
       </div>
     </div>
+  );
+}
+
+// ── Discretionary overlay variations ──────────────────────────────────────
+//
+// CliffCurve in production only plots take-home + benefit value. A
+// discretionary line used to live alongside it but was stripped when
+// discretionary was a noisier proxy. The four-axis CEX blend has since
+// made discretionary a real signal — the "lifestyle-inflation tail" of a
+// cliff lives entirely in the gap between the two metrics. This section
+// scaffolds four ways to bring discretionary back without re-introducing
+// the chrome that earned the original removal.
+//
+// Scenario: Columbus two-teachers, $110K combined, 2 kids — the same
+// configuration that surfaced the pit-warning bug. The CHIP cliff at
+// $69,630 produces a clear two-line divergence: take-home+benefits
+// recovers by ~$78K; discretionary doesn't recover until ~$110K because
+// income-elastic expenses keep eating the marginal paycheck.
+
+/** Curated subset of production scenarios that span the income spectrum
+ *  and household shapes useful for comparing dual-line behavior. The full
+ *  SCENARIOS list is overkill for a picker; these are the ones that produce
+ *  meaningfully different chart shapes. */
+const DISCRETIONARY_OVERLAY_SCENARIO_IDS = [
+  'retail_phx',
+  'teacher_oh',
+  'family_squeeze_nyc',
+  'median_cmh',
+  'tradesman_wy',
+  'tech_sf_family',
+  'exec_nyc',
+] as const;
+
+function scenarioToCliffScenario(s: (typeof SCENARIOS)[number]): CliffScenario {
+  const incomeB = s.incomeB ?? 0;
+  return {
+    city: s.city,
+    kids: s.kids,
+    filing: s.filing,
+    lifestyle: s.lifestyle,
+    // Married = always partnered. Cohabitating singles with a second income
+    // also count as partnered for the budget model.
+    hasPartner: s.filing === 'married' || incomeB > 0,
+    incomeA: s.income,
+    incomeB,
+  };
+}
+
+function SectionDiscretionaryOverlay() {
+  const scenarioOptions = React.useMemo(
+    () =>
+      DISCRETIONARY_OVERLAY_SCENARIO_IDS.map((id) => {
+        const s = SCENARIOS.find((x) => x.id === id);
+        if (!s) throw new Error(`Scenario ${id} missing from SCENARIOS`);
+        return s;
+      }),
+    [],
+  );
+  const [scenarioId, setScenarioId] = React.useState<string>(scenarioOptions[1].id);
+  const activeScenario = scenarioOptions.find((s) => s.id === scenarioId) ?? scenarioOptions[1];
+  const cliffScenario = React.useMemo(
+    () => scenarioToCliffScenario(activeScenario),
+    [activeScenario],
+  );
+  const scenarioLabel = `${activeScenario.label} · ${fmtMoney(
+    activeScenario.income + (activeScenario.incomeB ?? 0),
+  )} combined`;
+
+  return (
+    <Section
+      columns={1}
+      heading="Discretionary alongside take-home + benefits"
+      subhead="The cliff curve currently plots only take-home + benefit value. With CEX-indexed spending now in the model, the gap between that line and discretionary tells its own story — the lifestyle-inflation tail that lingers after a cliff. Four ways to surface both metrics without re-introducing the chrome that got the original toggle stripped. Picker below applies to every variation so you can compare them on the same household."
+    >
+      <ScenarioPicker scenarios={scenarioOptions} selected={scenarioId} onSelect={setScenarioId} />
+      <Variation
+        title="V1 — Dual-line overlay, same axes"
+        description="Both curves on one Y axis. Take-home + benefits in ink (the primary editorial line); discretionary in a softer warning tone, dashed. Single legend, no toggle. Reads as 'here's what you take in; here's what's actually free to spend.' Risk: two lines on the same axes can crowd at low incomes where they're far apart."
+      >
+        <DiscretionaryChartDualLine scenario={cliffScenario} label={scenarioLabel} />
+      </Variation>
+      <Variation
+        title="V2 — Small-multiple stack"
+        description="Two LineCharts stacked, sharing the X axis. Each owns its own Y so neither line gets crushed by the other's range. More chart real estate spent on this view, but every cliff fires in both panels and you can scan vertically to see the lifestyle-inflation gap."
+      >
+        <DiscretionaryChartSmallMultiple scenario={cliffScenario} label={scenarioLabel} />
+      </Variation>
+      <Variation
+        title="V3 — Filled diff-band between the lines"
+        description="Take-home + benefits as the top line. Discretionary as the bottom line. Tinted band fills the gap — the band IS lifestyle-driven spending. The wider the band, the more of every marginal dollar gets eaten before it becomes discretionary. Best for the editorial story we just uncovered; strongest visual claim on the page."
+      >
+        <DiscretionaryChartDiffBand scenario={cliffScenario} label={scenarioLabel} />
+      </Variation>
+      <Variation
+        title="V4 — Metric toggle (revival of the original)"
+        description="A chip-style toggle in the chart chrome swaps the rendered line between the two metrics. Single-line view stays calm; switching is a deliberate action. This is what production had before the strip; the question is whether the model's improvements justify bringing it back rather than picking a richer overlay."
+      >
+        <DiscretionaryChartToggle scenario={cliffScenario} label={scenarioLabel} />
+      </Variation>
+    </Section>
+  );
+}
+
+const fmtMoney = (n: number) =>
+  n >= 1000 ? `$${Math.round(n / 1000)}K` : `$${n.toLocaleString()}`;
+
+function ScenarioPicker({
+  scenarios,
+  selected,
+  onSelect,
+}: {
+  scenarios: ReadonlyArray<(typeof SCENARIOS)[number]>;
+  selected: string;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '12px 14px',
+        border: `1px solid ${T.border}`,
+        background: T.surface,
+        marginBottom: 12,
+      }}
+    >
+      <label
+        htmlFor="discretionary-overlay-scenario"
+        style={{
+          fontSize: rem(10),
+          letterSpacing: '0.16em',
+          textTransform: 'uppercase',
+          color: T.inkMuted,
+          fontWeight: 600,
+        }}
+      >
+        Scenario
+      </label>
+      <select
+        id="discretionary-overlay-scenario"
+        value={selected}
+        onChange={(e) => onSelect(e.target.value)}
+        style={{
+          fontFamily: fonts.body,
+          fontSize: rem(13),
+          color: T.ink,
+          background: T.bg,
+          border: `1px solid ${T.border}`,
+          padding: '6px 10px',
+          flex: 1,
+          minWidth: 0,
+        }}
+      >
+        {scenarios.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.label} · {fmtMoney(s.income + (s.incomeB ?? 0))} combined
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function DiscretionaryChartDualLine({
+  scenario,
+  label,
+}: {
+  scenario: CliffScenario;
+  label: string;
+}) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+  return (
+    <ScenarioFrame label={label}>
+      <ResponsiveContainer width="100%" height={280}>
+        <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={56}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.5}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey="takeHomePlusBenefits"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.warning}
+            strokeWidth={1.5}
+            strokeDasharray="4 3"
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.takeHomePlusBenefits ??
+              points[0].takeHomePlusBenefits
+            }
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <DualLegend />
+    </ScenarioFrame>
+  );
+}
+
+function DiscretionaryChartSmallMultiple({
+  scenario,
+  label,
+}: {
+  scenario: CliffScenario;
+  label: string;
+}) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+  const sharedX = (
+    <XAxis
+      dataKey="gross"
+      type="number"
+      domain={[0, maxGross]}
+      tickFormatter={fmtK}
+      stroke={T.inkMuted}
+      tick={{ fontSize: 10, fill: T.inkSoft }}
+    />
+  );
+  const cliffLines = cliffs.map((c) => (
+    <ReferenceLine
+      key={c.id}
+      x={c.gross}
+      stroke={c.color}
+      strokeDasharray="3 3"
+      strokeOpacity={0.5}
+    />
+  ));
+  return (
+    <ScenarioFrame label={label}>
+      <div
+        style={{
+          fontSize: rem(10),
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: T.inkSoft,
+          marginBottom: 4,
+        }}
+      >
+        Take-home + benefit value
+      </div>
+      <ResponsiveContainer width="100%" height={150}>
+        <LineChart data={points} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          {sharedX}
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={56}
+          />
+          {cliffLines}
+          <Line
+            type="monotone"
+            dataKey="takeHomePlusBenefits"
+            stroke={T.ink}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.takeHomePlusBenefits ??
+              points[0].takeHomePlusBenefits
+            }
+            r={3.5}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+      <div
+        style={{
+          fontSize: rem(10),
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: T.inkSoft,
+          margin: '10px 0 4px',
+        }}
+      >
+        Discretionary (after expenses)
+      </div>
+      <ResponsiveContainer width="100%" height={150}>
+        <LineChart data={points} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          {sharedX}
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={56}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffLines}
+          <Line
+            type="monotone"
+            dataKey="discretionary"
+            stroke={T.warning}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={
+              points.find((p) => p.gross >= currentGross)?.discretionary ?? points[0].discretionary
+            }
+            r={3.5}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+function DiscretionaryChartDiffBand({
+  scenario,
+  label,
+}: {
+  scenario: CliffScenario;
+  label: string;
+}) {
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+  // Render the band as a stacked area: bottom = discretionary, fill on
+  // top = (takeHomePlusBenefits - discretionary). The visible band is the
+  // expense burden between the two lines.
+  const banded = points.map((p) => ({
+    gross: p.gross,
+    discretionary: p.discretionary,
+    expenseBurden: Math.max(0, p.takeHomePlusBenefits - p.discretionary),
+    takeHomePlusBenefits: p.takeHomePlusBenefits,
+  }));
+  return (
+    <ScenarioFrame label={label}>
+      <ResponsiveContainer width="100%" height={280}>
+        <ComposedAreaChart data={banded} cliffs={cliffs} maxGross={maxGross} />
+      </ResponsiveContainer>
+      <div
+        style={{
+          fontSize: rem(11),
+          color: T.inkSoft,
+          marginTop: 6,
+          lineHeight: 1.4,
+        }}
+      >
+        Black line: take-home + benefits. Warning line: discretionary. The tinted band between them
+        is income-elastic spending — what gets eaten before the marginal dollar lands in
+        discretionary.
+      </div>
+      <ReferenceDotOverlay points={banded} currentGross={currentGross} />
+    </ScenarioFrame>
+  );
+}
+
+/** Stacked-area + line composite. Recharts doesn't allow stacked Areas
+ *  with a non-zero baseline directly, so we render the band as a single
+ *  Area whose data points are pre-computed as [discretionary, takeHome+ben].
+ *  See `banded` above for the shape. */
+function ComposedAreaChart({
+  data,
+  cliffs,
+  maxGross,
+}: {
+  data: { gross: number; discretionary: number; takeHomePlusBenefits: number }[];
+  cliffs: CliffMark[];
+  maxGross: number;
+}) {
+  // Convert each row to a "band" range using the [low, high] array form
+  // Recharts supports for Area baselines via `dataKey` returning a tuple.
+  const bandData = data.map((p) => ({
+    gross: p.gross,
+    band: [p.discretionary, p.takeHomePlusBenefits] as [number, number],
+    discretionary: p.discretionary,
+    takeHomePlusBenefits: p.takeHomePlusBenefits,
+  }));
+  return (
+    <LineChart data={bandData} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+      <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+      <XAxis
+        dataKey="gross"
+        type="number"
+        domain={[0, maxGross]}
+        tickFormatter={fmtK}
+        stroke={T.inkMuted}
+        tick={{ fontSize: 10, fill: T.inkSoft }}
+      />
+      <YAxis
+        tickFormatter={fmtK}
+        stroke={T.inkMuted}
+        tick={{ fontSize: 10, fill: T.inkSoft }}
+        width={56}
+      />
+      <ReferenceLine y={0} stroke={T.inkMuted} />
+      {cliffs.map((c) => (
+        <ReferenceLine
+          key={c.id}
+          x={c.gross}
+          stroke={c.color}
+          strokeDasharray="3 3"
+          strokeOpacity={0.5}
+        />
+      ))}
+      {/* Band drawn as two stroke-less area lines using a custom fill.
+          Recharts Area with `dataKey` of tuple gives the band shape, but
+          we're inside a LineChart for consistency with siblings — fall
+          back to per-segment vertical reference areas to draw the band. */}
+      {bandData.map((p, i) => {
+        if (i === 0) return null;
+        const prev = bandData[i - 1];
+        const x1 = prev.gross;
+        const x2 = p.gross;
+        return (
+          <ReferenceArea
+            key={i}
+            x1={x1}
+            x2={x2}
+            y1={Math.min(prev.discretionary, p.discretionary)}
+            y2={Math.max(prev.takeHomePlusBenefits, p.takeHomePlusBenefits)}
+            fill={T.warning}
+            fillOpacity={0.07}
+            stroke="none"
+          />
+        );
+      })}
+      <Line
+        type="monotone"
+        dataKey="discretionary"
+        stroke={T.warning}
+        strokeWidth={1.5}
+        dot={false}
+        isAnimationActive={false}
+      />
+      <Line
+        type="monotone"
+        dataKey="takeHomePlusBenefits"
+        stroke={T.ink}
+        strokeWidth={2}
+        dot={false}
+        isAnimationActive={false}
+      />
+    </LineChart>
+  );
+}
+
+/** Overlay-only "current income" dot — kept outside the chart so each
+ *  variation can drop one in without re-deriving the y position. */
+function ReferenceDotOverlay({
+  points,
+  currentGross,
+}: {
+  points: { gross: number; takeHomePlusBenefits: number; discretionary: number }[];
+  currentGross: number;
+}) {
+  const p = points.find((q) => q.gross >= currentGross) ?? points[0];
+  return (
+    <div style={{ fontSize: rem(11), color: T.inkSoft, marginTop: 2 }}>
+      At {fmtK(currentGross)} the household has{' '}
+      <strong style={{ color: T.ink }}>{fmtK(p.takeHomePlusBenefits)}</strong> in take-home +
+      benefits and <strong style={{ color: T.warning }}>{fmtK(p.discretionary)}</strong> in
+      discretionary — a {fmtK(p.takeHomePlusBenefits - p.discretionary)} expense burden.
+    </div>
+  );
+}
+
+function DiscretionaryChartToggle({ scenario, label }: { scenario: CliffScenario; label: string }) {
+  const [metric, setMetric] = React.useState<'takeHomePlusBenefits' | 'discretionary'>(
+    'takeHomePlusBenefits',
+  );
+  const { points, cliffs, maxGross, currentGross } = useCliffScenario(scenario);
+  const lineColor = metric === 'takeHomePlusBenefits' ? T.ink : T.warning;
+  return (
+    <ScenarioFrame label={label}>
+      <div
+        style={{
+          display: 'flex',
+          gap: 6,
+          marginBottom: 8,
+          fontSize: rem(11),
+        }}
+      >
+        <ToggleChip
+          label="Take-home + benefits"
+          active={metric === 'takeHomePlusBenefits'}
+          onClick={() => setMetric('takeHomePlusBenefits')}
+        />
+        <ToggleChip
+          label="Discretionary"
+          active={metric === 'discretionary'}
+          onClick={() => setMetric('discretionary')}
+        />
+      </div>
+      <ResponsiveContainer width="100%" height={260}>
+        <LineChart data={points} margin={{ top: 12, right: 16, left: 0, bottom: 8 }}>
+          <CartesianGrid stroke={T.border} strokeDasharray="2 4" vertical={false} />
+          <XAxis
+            dataKey="gross"
+            type="number"
+            domain={[0, maxGross]}
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+          />
+          <YAxis
+            tickFormatter={fmtK}
+            stroke={T.inkMuted}
+            tick={{ fontSize: 10, fill: T.inkSoft }}
+            width={56}
+          />
+          <ReferenceLine y={0} stroke={T.inkMuted} />
+          {cliffs.map((c) => (
+            <ReferenceLine
+              key={c.id}
+              x={c.gross}
+              stroke={c.color}
+              strokeDasharray="3 3"
+              strokeOpacity={0.5}
+            />
+          ))}
+          <Line
+            type="monotone"
+            dataKey={metric}
+            stroke={lineColor}
+            strokeWidth={2}
+            dot={false}
+            isAnimationActive={false}
+          />
+          <ReferenceDot
+            x={currentGross}
+            y={(points.find((p) => p.gross >= currentGross) ?? points[0])[metric]}
+            r={4}
+            fill={T.positive}
+            stroke={T.bg}
+            strokeWidth={2}
+            ifOverflow="visible"
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ScenarioFrame>
+  );
+}
+
+function ToggleChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        fontSize: rem(11),
+        letterSpacing: '0.06em',
+        padding: '4px 10px',
+        border: `1px solid ${active ? T.ink : T.border}`,
+        background: active ? T.ink : 'transparent',
+        color: active ? T.bg : T.inkSoft,
+        cursor: 'pointer',
+        borderRadius: 2,
+        fontFamily: fonts.body,
+      }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function DualLegend() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+        marginTop: 6,
+        fontSize: rem(11),
+        color: T.inkSoft,
+      }}
+    >
+      <LegendSwatch color={T.ink} dashed={false} label="Take-home + benefits" />
+      <LegendSwatch color={T.warning} dashed label="Discretionary (after expenses)" />
+    </div>
+  );
+}
+
+function LegendSwatch({ color, dashed, label }: { color: string; dashed: boolean; label: string }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      <span
+        style={{
+          display: 'inline-block',
+          width: 22,
+          height: 0,
+          borderTop: `2px ${dashed ? 'dashed' : 'solid'} ${color}`,
+        }}
+      />
+      {label}
+    </span>
   );
 }


### PR DESCRIPTION
## Summary

- **Cliff curve** now plots both **take-home + benefit value** (solid ink, primary) and **discretionary** (dashed warning, secondary) on the same axes. The gap between the two lines IS income-elastic spending — the lifestyle-inflation tail that lingers after a cliff. Decided in `/design-lab#discretionary-overlay` after kicking V1–V4 through a scenario picker.
- **Pit warning** now compares on take-home + benefit value instead of discretionary. The old metric conflated genuine benefits cliffs (a one-time hit at the threshold) with the lifestyle-inflation tail, surfacing trailing-edge $9 deltas as scary warnings (the bug that started this thread). Floor at `PIT_MIN_DELTA = 500` filters wash-zone noise; warning + chart now read off the same metric so they can't drift.
- **Bonus fix:** both sweep helpers (`findIncomePit` and design-lab's `useCliffScenario`) held `incomeB` fixed and only varied `incomeA`, collapsing every `g < incomeB` onto the same household income. Production `CliffCurve` switched to proportional scaling a while back; the two copy-paste callers didn't get the memo. Visible as a flat plateau in dual-earner scenarios. Now both scale proportionally.
- **Roadmap entries** for [#257 Section 8 housing vouchers](https://github.com/TheBudgetAtlas/thebudgetatlas/issues/257), [#258 ACA premium tax credits](https://github.com/TheBudgetAtlas/thebudgetatlas/issues/258), [#259 Child & Dependent Care Credit](https://github.com/TheBudgetAtlas/thebudgetatlas/issues/259), [#260 Industry compensation profile](https://github.com/TheBudgetAtlas/thebudgetatlas/issues/260) — the four largest missing pieces surfaced while reasoning about why so many households read as underwater under $100K.

## Test plan

- [x] `yarn test` — 179 pass, including new `cliffs.test.ts`
- [x] `yarn lint`
- [x] `yarn build`
- [ ] Manual: open `/` and verify the cliff curve renders both lines with the new legend across a range of scenarios (try the construction-worker / rural Wyoming case for the cleanest dual-line story)
- [ ] Manual: open `/#design-lab#discretionary-overlay` and confirm the scenario picker drives all four variants
- [ ] Manual: confirm the pit warning no longer fires on the Columbus two-teachers $110K case (the original reported bug) and still fires on configurations sitting inside a real cliff trough (e.g. Columbus two-teachers with `incomeA=16500, incomeB=54000` — just past the CHIP cutoff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)